### PR TITLE
Enhancement: Synchronize project tooling configuration with ergebnis/php-cs-fixer-config-template

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,9 +11,12 @@ update_configs:
       - "localheinz"
     directory: "/"
     package_manager: "github_actions"
-    update_schedule: "weekly"
+    update_schedule: "daily"
 
-  - default_assignees:
+  - automerged_updates:
+      - match:
+          dependency_type: "development"
+    default_assignees:
       - "localheinz"
     default_labels:
       - "dependency"
@@ -21,5 +24,5 @@ update_configs:
       - "localheinz"
     directory: "/"
     package_manager: "php:composer"
-    update_schedule: "weekly"
+    update_schedule: "daily"
     version_requirement_updates: "increase_versions"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,18 @@ $ make coding-standards
 
 to automatically fix coding standard violations.
 
+## Dependency Analysis
+
+We are using [`maglnet/composer-require-checker`](https://github.com/maglnet/ComposerRequireChecker) to prevent the use of unknown symbols in production code.
+
+Run
+
+```
+$ make dependency-analysis
+```
+
+to run a dependency analysis.
+
 ## Static Code Analysis
 
 We are using [`phpstan/phpstan`](https://github.com/phpstan/phpstan) to statically analyze the code.
@@ -72,7 +84,7 @@ Run
 $ make
 ```
 
-to enforce coding standards, perform a static code analysis, and run tests!
+to enforce coding standards, run a dependency analysis, run a static code analysis, and run tests!
 
 ## Help
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,7 +27,7 @@ final class Factory
      *
      * @return Config
      */
-    public static function fromRuleSet(RuleSet $ruleSet, array $overrideRules = [])
+    public static function fromRuleSet(RuleSet $ruleSet, array $overrideRules = []): Config
     {
         if (\PHP_VERSION_ID < $ruleSet->targetPhpVersion()) {
             throw new \RuntimeException(\sprintf(


### PR DESCRIPTION
This PR

* [x] synchronizes the project tooling configuration with [`ergebnis/php-cs-fixer-config-template`](https://github.com/ergebnis/php-cs-fixer-config-template).