### PR TITLE
Enhancement: Use ergebnis/test-util instead of localheinz/test-util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "localheinz/php-cs-fixer-config": "*"
   },
   "require-dev": {
+    "ergebnis/test-util": "~0.9.0",
     "infection/infection": "~0.14.2",
     "jangregor/phpstan-prophecy": "~0.4.2",
     "localheinz/composer-normalize": "^1.3.1",
     "localheinz/phpstan-rules": "~0.13.0",
-    "localheinz/test-util": "~0.8.0",
     "phpstan/phpstan": "~0.11.19",
     "phpstan/phpstan-deprecation-rules": "~0.11.2",
     "phpstan/phpstan-strict-rules": "~0.11.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccead3b133f25f1bac4f75aac33647f1",
+    "content-hash": "36785227cbda4c51ba156d5f33966b70",
     "packages": [
         {
             "name": "composer/semver",
@@ -1385,6 +1385,112 @@
             "time": "2019-10-21T16:45:58+00:00"
         },
         {
+            "name": "ergebnis/classy",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/classy.git",
+                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/classy/zipball/7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
+                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "infection/infection": "~0.15.0",
+                "localheinz/composer-normalize": "^1.3.1",
+                "localheinz/phpstan-rules": "~0.13.0",
+                "localheinz/test-util": "0.2.2",
+                "phpbench/phpbench": "~0.16.10",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.4.3",
+                "zendframework/zend-file": "^2.8.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Classy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a way to collect classy constructs from source or a directory.",
+            "homepage": "https://github.com/ergebnis/classy",
+            "time": "2019-12-05T22:45:51+00:00"
+        },
+        {
+            "name": "ergebnis/test-util",
+            "version": "0.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/test-util.git",
+                "reference": "c3e52e5ccbe7d70fd902fd19cb3ab3747ee9c3e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/test-util/zipball/c3e52e5ccbe7d70fd902fd19cb3ab3747ee9c3e1",
+                "reference": "c3e52e5ccbe7d70fd902fd19cb3ab3747ee9c3e1",
+                "shasum": ""
+            },
+            "require": {
+                "ergebnis/classy": "~0.5.0",
+                "fzaninotto/faker": "^1.9.0",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "infection/infection": "~0.15.0",
+                "localheinz/composer-normalize": "^1.3.1",
+                "localheinz/phpstan-rules": "~0.13.0",
+                "phpstan/phpstan": "~0.11.6",
+                "phpstan/phpstan-phpunit": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^7.5.16 || ^8.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Test\\Util\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides utilities for tests.",
+            "homepage": "https://github.com/ergebnis/test-util",
+            "keywords": [
+                "assertion",
+                "faker",
+                "phpunit",
+                "test"
+            ],
+            "time": "2019-12-07T08:19:59+00:00"
+        },
+        {
             "name": "fzaninotto/faker",
             "version": "v1.9.0",
             "source": {
@@ -1698,48 +1804,6 @@
                 "schema"
             ],
             "time": "2019-09-25T14:49:45+00:00"
-        },
-        {
-            "name": "localheinz/classy",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/classy.git",
-                "reference": "8f1413f01a464f88521eac735f0e62b02da9ac67"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/classy/zipball/8f1413f01a464f88521eac735f0e62b02da9ac67",
-                "reference": "8f1413f01a464f88521eac735f0e62b02da9ac67",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "localheinz/php-cs-fixer-config": "~1.6.2",
-                "localheinz/test-util": "0.2.2",
-                "phpbench/phpbench": "0.13.0",
-                "phpunit/phpunit": "^6.4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\Classy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a way to collect classy constructs from source or a directory.",
-            "time": "2017-10-24T14:31:40+00:00"
         },
         {
             "name": "localheinz/composer-json-normalizer",
@@ -2072,61 +2136,6 @@
                 "phpstan-rules"
             ],
             "time": "2019-10-15T09:23:25+00:00"
-        },
-        {
-            "name": "localheinz/test-util",
-            "version": "0.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/test-util.git",
-                "reference": "75a2719bc7bb846219adb3379fda5ce79cc9091b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/test-util/zipball/75a2719bc7bb846219adb3379fda5ce79cc9091b",
-                "reference": "75a2719bc7bb846219adb3379fda5ce79cc9091b",
-                "shasum": ""
-            },
-            "require": {
-                "fzaninotto/faker": "^1.8.0",
-                "localheinz/classy": "0.3.0",
-                "php": "^7.2"
-            },
-            "require-dev": {
-                "infection/infection": "~0.11.4",
-                "localheinz/composer-normalize": "^1.0.0",
-                "localheinz/php-cs-fixer-config": "~1.23.0",
-                "localheinz/phpstan-rules": "~0.5.0",
-                "phpstan/phpstan": "~0.10.5",
-                "phpstan/phpstan-phpunit": "~0.10.0",
-                "phpstan/phpstan-strict-rules": "~0.10.1",
-                "phpunit/phpunit": "^7.5.16 || ^8.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\Test\\Util\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides utilities for tests.",
-            "homepage": "https://github.com/localheinz/test-util",
-            "keywords": [
-                "assertion",
-                "faker",
-                "phpunit",
-                "test"
-            ],
-            "time": "2019-10-22T18:17:06+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\AutoReview;
 
-use Localheinz\Test\Util\Helper;
+use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/test-util` instead of `localheinz/test-util`