### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.1.0...master`][1.1.0...master].
+For a full diff see [`1.1.1...master`][1.1.1...master].
+
+## [`1.1.1`][1.1.1]
+
+For a full diff see [`1.1.0...1.1.1`][1.1.0...1.1.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#14]), by [@localheinz]
 
 ## [`1.1.0`][1.1.0]
 
@@ -21,12 +29,16 @@ For a full diff see [`1.0.0...1.1.0`][1.0.0...1.1.0].
 For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 
 [1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/1.0.0
-[1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/1.2.0
+[1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/1.1.0
+[1.1.1]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/1.1.1
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
-[1.1.0...master]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.0...master
+[1.1.0...1.1.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.0...1.1.1
+[1.1.1...master]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.1...master
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
+[#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
 
 [@linuxjuggler]: https://github.com/linuxjuggler
+[@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
     "php": "^7.2",
     "friendsofphp/php-cs-fixer": "~2.16.0"
   },
-  "replace": {
-    "localheinz/php-cs-fixer-config": "*"
-  },
   "require-dev": {
     "ergebnis/phpstan-rules": "~0.14.0",
     "ergebnis/test-util": "~0.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e6420bda987adabebea4edd63741c17",
+    "content-hash": "7a8bc9dde2f2f08275b5a9285e12cd30",
     "packages": [
         {
             "name": "composer/semver",


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`