### PR TITLE
Enhancement: Allow creation of Year from current UTC time

### DIFF
--- a/src/Header/Year.php
+++ b/src/Header/Year.php
@@ -44,6 +44,16 @@ final class Year
         return new self($value);
     }
 
+    public static function current(): self
+    {
+        $value = new \DateTimeImmutable(
+            'now',
+            new \DateTimeZone('UTC')
+        );
+
+        return self::fromString($value->format('Y'));
+    }
+
     public function toString(): string
     {
         return $this->value;

--- a/test/Unit/Header/YearTest.php
+++ b/test/Unit/Header/YearTest.php
@@ -92,6 +92,18 @@ final class YearTest extends Framework\TestCase
         }
     }
 
+    public function testCurrentReturnsYearWithUtcValue(): void
+    {
+        $value = new \DateTimeImmutable(
+            'now',
+            new \DateTimeZone('UTC')
+        );
+
+        $year = Year::current();
+
+        self::assertSame($value->format('Y'), $year->toString());
+    }
+
     public function testEqualsReturnsFalseWhenValueIsDifferent(): void
     {
         $one = Year::fromString('2020');


### PR DESCRIPTION
This PR

* [x] allows the creation of a `Year` from current UTC time

Follows #23.