### PR TITLE
Fix: Add missing release to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,23 @@ For a full diff see [`2.0.0...master`][2.0.0...master].
 
 ## [`2.0.0`][2.0.0]
 
-For a full diff see [`1.1.2...2.0.0`][1.1.2...2.0.0].
+For a full diff see [`1.1.3...2.0.0`][1.1.3...2.0.0].
 
 ### Removed
 
 * Removed classes uses for construction of header, use [`ergebnis/license`](https://github.com/ergebnis/license) instead ([#50]), by [@localheinz]
 
-## [`1.1.2`][1.1.2]
+## [`1.1.3`][1.1.3]
 
-For a full diff see [`1.1.1...1.1.2`][1.1.1...1.1.2].
+For a full diff see [`1.1.2...1.1.3`][1.1.2...1.1.3].
 
 ### Added
 
 * Allowed construction of header ([#23]), by [@localheinz]
+
+## [`1.1.2`][1.1.2]
+
+For a full diff see [`1.1.1...1.1.2`][1.1.1...1.1.2].
 
 ### Fixed
 
@@ -58,7 +62,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
 [1.1.0...1.1.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.0...1.1.1
 [1.1.1...1.1.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.1...1.1.2
-[1.1.2...2.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.2...2.0.0
+[1.1.2...1.1.3]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.2...1.1.3
+[1.1.3...2.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.3...2.0.0
 [2.0.0...master]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.0.0...master
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3


### PR DESCRIPTION
This PR

* [x] adds a missing release to `CHANGELOG.md`