### PR TITLE
Fix: Synchronize with ergebnis/php-cs-fixer-config-template

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -62,5 +62,5 @@ rules:
       - "true"
 
 yaml-files:
-  - '*.yaml'
-  - '*.yml'
+  - "*.yaml"
+  - "*.yml"


### PR DESCRIPTION
This PR

* [x] synchronizes with [`ergebnis/php-cs-fixer-config-template`](https://github.com/ergebnis/php-cs-fixer-config-template)
