### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -83,7 +83,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":notebook: Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.1.0...master`][2.1.0...master].
+For a full diff see [`2.1.0...main`][2.1.0...main].
 
 ## [`2.1.0`][2.1.0]
 
@@ -75,7 +75,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [1.1.2...1.1.3]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.2...1.1.3
 [1.1.3...2.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.3...2.0.0
 [2.0.0...2.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.0.0...2.1.0
-[2.1.0...master]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.1.0...master
+[2.1.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.1.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # php-cs-fixer-config
 
-[![Integrate](https://github.com/ergebnis/php-cs-fixer-config/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/php-cs-fixer-config/actions)
-[![Prune](https://github.com/ergebnis/php-cs-fixer-config/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/php-cs-fixer-config/actions)
-[![Release](https://github.com/ergebnis/php-cs-fixer-config/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/php-cs-fixer-config/actions)
-[![Renew](https://github.com/ergebnis/php-cs-fixer-config/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/php-cs-fixer-config/actions)
+[![Integrate](https://github.com/ergebnis/php-cs-fixer-config/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/php-cs-fixer-config/actions)
+[![Prune](https://github.com/ergebnis/php-cs-fixer-config/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/php-cs-fixer-config/actions)
+[![Release](https://github.com/ergebnis/php-cs-fixer-config/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/php-cs-fixer-config/actions)
+[![Renew](https://github.com/ergebnis/php-cs-fixer-config/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/php-cs-fixer-config/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/php-cs-fixer-config/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/php-cs-fixer-config)
+[![Code Coverage](https://codecov.io/gh/ergebnis/php-cs-fixer-config/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/php-cs-fixer-config)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/php-cs-fixer-config/coverage.svg)](https://shepherd.dev/github/ergebnis/php-cs-fixer-config)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/php-cs-fixer-config/v/stable)](https://packagist.org/packages/ergebnis/php-cs-fixer-config)
@@ -183,7 +183,7 @@ If you like [GitHub Actions](https://github.com/features/actions), add a `coding
    pull_request:
    push:
      branches:
-       - master
+       - main
      tags:
        - "**"
 
@@ -268,7 +268,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.