### PR TITLE
Enhancement: Configure ordered_imports fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.1.0...main`][2.1.0...main].
+For a full diff see [`2.2.0...main`][2.2.0...main].
+
+## [`2.2.0`][2.2.0]
+
+For a full diff see [`2.1.2...2.2.0`][2.1.2...2.2.0].
+
+### Changed
+
+* Configured `ordered_imports` fixer to group imports by kind ([#133]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 
@@ -67,6 +75,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [1.1.3]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/1.1.3
 [2.0.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.0.0
 [2.1.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.1.0
+[2.2.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -75,7 +84,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [1.1.2...1.1.3]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.2...1.1.3
 [1.1.3...2.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.1.3...2.0.0
 [2.0.0...2.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.0.0...2.1.0
-[2.1.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.1.0...main
+[2.1.2...2.2.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.1.2...2.2.0
+[2.2.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -83,6 +93,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#23]: https://github.com/ergebnis/php-cs-fixer-config/pull/23
 [#50]: https://github.com/ergebnis/php-cs-fixer-config/pull/50
 [#73]: https://github.com/ergebnis/php-cs-fixer-config/pull/73
+[#133]: https://github.com/ergebnis/php-cs-fixer-config/pull/133
 
 [@linuxjuggler]: https://github.com/linuxjuggler
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use PhpCsFixer\Fixer;
+
 final class Php71 extends AbstractRuleSet
 {
     protected $name = 'ergebnis (PHP 7.1)';
@@ -212,7 +214,13 @@ final class Php71 extends AbstractRuleSet
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => [
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+            ],
+        ],
         'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use PhpCsFixer\Fixer;
+
 final class Php73 extends AbstractRuleSet
 {
     protected $name = 'ergebnis (PHP 7.3)';
@@ -212,7 +214,13 @@ final class Php73 extends AbstractRuleSet
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => [
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+            ],
+        ],
         'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use PhpCsFixer\Fixer;
+
 /**
  * @internal
  *
@@ -218,7 +220,13 @@ final class Php71Test extends AbstractRuleSetTestCase
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => [
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+            ],
+        ],
         'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use PhpCsFixer\Fixer;
+
 /**
  * @internal
  *
@@ -218,7 +220,13 @@ final class Php73Test extends AbstractRuleSetTestCase
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
         'ordered_class_elements' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => [
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
+                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+            ],
+        ],
         'ordered_interfaces' => true,
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => [


### PR DESCRIPTION
This PR

* [x] configures the `ordered_imports` fixer to group imports by kind

💁‍♂️ Inspired by https://github.com/sebastianbergmann/phpunit/commit/899db927169682058ed8875c3d0c7f30c1fa4ed2.