### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -195,7 +195,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.2.1...main`][2.2.1...main].
+For a full diff see [`2.2.2...main`][2.2.2...main].
+
+## [`2.2.2`][2.2.2]
+
+For a full diff see [`2.2.1...2.2.2`][2.2.1...2.2.2].
+
+### Changed
+
+* Dropped support for PHP 7.1 ([#168]), by [@dependabot]
 
 ## [`2.2.1`][2.2.1]
 
@@ -85,6 +93,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.1.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.1.0
 [2.2.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.0
 [2.2.1]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.1
+[2.2.2]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.2
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -95,7 +104,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.0.0...2.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.0.0...2.1.0
 [2.1.2...2.2.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.1.2...2.2.0
 [2.2.0...2.2.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.0...2.2.1
-[2.2.1...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.1...main
+[2.2.1...2.2.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.1...2.2.2
+[2.2.2...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.2...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -105,6 +115,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#73]: https://github.com/ergebnis/php-cs-fixer-config/pull/73
 [#133]: https://github.com/ergebnis/php-cs-fixer-config/pull/133
 [#135]: https://github.com/ergebnis/php-cs-fixer-config/pull/135
+[#168]: https://github.com/ergebnis/php-cs-fixer-config/pull/168
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ext-filter": "*",
     "friendsofphp/php-cs-fixer": "~2.16.4"
   },
@@ -34,7 +34,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef567eecfe5b1b43e378f46455034d1c",
+    "content-hash": "5015a220f130979e3c3d8680be49689b",
     "packages": [
         {
             "name": "composer/semver",
@@ -5277,12 +5277,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-filter": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.