### PR TITLE
Enhancement: Enable and configure no_superfluous_phpdoc_tags fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.3.0...main`][2.3.0...main].
+For a full diff see [`2.4.0...main`][2.4.0...main].
+
+## [`2.4.0`][2.4.0]
+
+For a full diff see [`2.3.0...2.4.0`][2.3.0...2.4.0].
+
+### Changed
+
+* Enabled `no_superfluous_phpdoc_tags` fixer ([#215]), by [@localheinz]
 
 ## [`2.3.0`][2.3.0]
 
@@ -103,6 +111,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.2.1]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.1
 [2.2.2]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.2
 [2.3.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.3.0
+[2.4.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.4.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -115,7 +124,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.2.0...2.2.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.0...2.2.1
 [2.2.1...2.2.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.1...2.2.2
 [2.2.2...2.3.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.1...2.3.0
-[2.3.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.3.0...main
+[2.3.0...2.4.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.3.0...2.4.0
+[2.4.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.4.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -127,6 +137,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#135]: https://github.com/ergebnis/php-cs-fixer-config/pull/135
 [#168]: https://github.com/ergebnis/php-cs-fixer-config/pull/168
 [#200]: https://github.com/ergebnis/php-cs-fixer-config/pull/200
+[#215]: https://github.com/ergebnis/php-cs-fixer-config/pull/215
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -20,12 +20,7 @@ final class Factory
     /**
      * Creates a configuration based on a rule set.
      *
-     * @param RuleSet $ruleSet
-     * @param array   $overrideRules
-     *
      * @throws \RuntimeException
-     *
-     * @return Config
      */
     public static function fromRuleSet(RuleSet $ruleSet, array $overrideRules = []): Config
     {

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -17,15 +17,11 @@ interface RuleSet
 {
     /**
      * Returns the name of the rule set.
-     *
-     * @return string
      */
     public function name(): string;
 
     /**
      * Returns an array of rules along with their configuration.
-     *
-     * @return array
      */
     public function rules(): array;
 
@@ -33,8 +29,6 @@ interface RuleSet
      * Returns the minimum required PHP version (PHP_VERSION_ID).
      *
      * @see http://php.net/manual/en/reserved.constants.php
-     *
-     * @return int
      */
     public function targetPhpVersion(): int;
 }

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -193,7 +193,11 @@ final class Php71 extends AbstractRuleSet
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
-        'no_superfluous_phpdoc_tags' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'remove_inheritdoc' => false,
+        ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -193,7 +193,11 @@ final class Php73 extends AbstractRuleSet
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
-        'no_superfluous_phpdoc_tags' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'remove_inheritdoc' => false,
+        ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -192,7 +192,11 @@ final class Php74 extends AbstractRuleSet
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
-        'no_superfluous_phpdoc_tags' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'remove_inheritdoc' => false,
+        ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -66,8 +66,6 @@ final class FactoryTest extends Framework\TestCase
 
     /**
      * @dataProvider providerTargetPhpVersion
-     *
-     * @param int $targetPhpVersion
      */
     public function testFromRuleSetCreatesConfig(int $targetPhpVersion): void
     {

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -127,7 +127,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     /**
      * @dataProvider providerRuleNames
      *
-     * @param string   $source
      * @param string[] $ruleNames
      */
     final public function testRulesAreSortedByName(string $source, array $ruleNames): void
@@ -159,8 +158,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
     /**
      * @throws \RuntimeException
-     *
-     * @return string
      */
     final protected static function className(): string
     {
@@ -188,8 +185,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
      * @param string $header
      *
      * @throws \RuntimeException
-     *
-     * @return Config\RuleSet
      */
     final protected static function createRuleSet($header = null): Config\RuleSet
     {

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -199,7 +199,11 @@ final class Php71Test extends AbstractRuleSetTestCase
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
-        'no_superfluous_phpdoc_tags' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'remove_inheritdoc' => false,
+        ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -199,7 +199,11 @@ final class Php73Test extends AbstractRuleSetTestCase
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
-        'no_superfluous_phpdoc_tags' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'remove_inheritdoc' => false,
+        ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -198,7 +198,11 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_singleline_whitespace_before_semicolons' => true,
         'no_spaces_around_offset' => true,
         'no_superfluous_elseif' => true,
-        'no_superfluous_phpdoc_tags' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+            'allow_unused_params' => false,
+            'remove_inheritdoc' => false,
+        ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_unneeded_control_parentheses' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `no_superfluous_phpdoc_tags`
* [x] runs `make cs`


💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.4#usage:

> **no_superfluous_phpdoc_tags** [`@Symfony`, `@PhpCsFixer`]
>
>Removes `@param`, `@return` and `@var` tags that don't provide any useful information.
>
>Configuration options:
>
>* `allow_mixed` (`bool`): whether type mixed without description is allowed (`true`) or considered superfluous (`false`); defaults to `false`
>* `allow_unused_params` (`bool`): whether param annotation without actual signature is allowed (`true`) or considered superfluous (`false`); defaults to `false`
>* `remove_inheritdoc` (`bool`): remove `@inheritDoc` tags; defaults to `false`