### PR TITLE
Enhancement: Configure phpdoc_add_missing_param_annotation fixer to add annotation for untyped parameters only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.4.0...main`][2.4.0...main].
+For a full diff see [`2.5.0...main`][2.5.0...main].
+
+## [`2.5.0`][2.5.0]
+
+For a full diff see [`2.4.0...2.5.0`][2.4.0...2.5.0].
+
+### Changed
+
+* Configured the `phpdoc_add_missing_param_annotation` fixer to add annotation for untyped parameters only ([#220]), by [@localheinz]
 
 ## [`2.4.0`][2.4.0]
 
@@ -112,6 +120,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.2.2]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.2.2
 [2.3.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.3.0
 [2.4.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.4.0
+[2.5.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.5.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -125,7 +134,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.2.1...2.2.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.1...2.2.2
 [2.2.2...2.3.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.2.1...2.3.0
 [2.3.0...2.4.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.3.0...2.4.0
-[2.4.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.4.0...main
+[2.4.0...2.5.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.4.0...2.5.0
+[2.5.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.5.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -138,6 +148,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#168]: https://github.com/ergebnis/php-cs-fixer-config/pull/168
 [#200]: https://github.com/ergebnis/php-cs-fixer-config/pull/200
 [#215]: https://github.com/ergebnis/php-cs-fixer-config/pull/215
+[#220]: https://github.com/ergebnis/php-cs-fixer-config/pull/220
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -262,7 +262,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
-            'only_untyped' => false,
+            'only_untyped' => true,
         ],
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -262,7 +262,7 @@ final class Php73 extends AbstractRuleSet
         ],
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
-            'only_untyped' => false,
+            'only_untyped' => true,
         ],
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -261,7 +261,7 @@ final class Php74 extends AbstractRuleSet
         ],
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
-            'only_untyped' => false,
+            'only_untyped' => true,
         ],
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -180,8 +180,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     }
 
     /**
-     * @param ?string $header
-     *
      * @throws \RuntimeException
      */
     final protected static function createRuleSet(?string $header = null): Config\RuleSet

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -268,7 +268,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
-            'only_untyped' => false,
+            'only_untyped' => true,
         ],
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -268,7 +268,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         ],
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
-            'only_untyped' => false,
+            'only_untyped' => true,
         ],
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -267,7 +267,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         ],
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => [
-            'only_untyped' => false,
+            'only_untyped' => true,
         ],
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_add_missing_param_annotation` fixer to add annotations for untyped parameters only
* [x] removes an unnecessary annotation
