### PR TITLE
Fix: Use class names as keys

### DIFF
--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -159,8 +159,8 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     final public function provideRuleNames(): \Generator
     {
         $values = [
-            'rule set' => self::createRuleSet()->rules(),
-            'test' => $this->rules,
+            static::className() => self::createRuleSet()->rules(),
+            static::class => $this->rules,
         ];
 
         foreach ($values as $source => $rules) {


### PR DESCRIPTION
This PR

* [x] uses class names as keys