### PR TITLE
Fix: Remove static variable

### DIFF
--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -224,17 +224,14 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
      */
     private static function builtInFixerNames(): array
     {
-        static $builtInFixerNames;
+        $fixerFactory = FixerFactory::create();
 
-        if (null === $builtInFixerNames) {
-            $fixerFactory = FixerFactory::create();
-            $fixerFactory->registerBuiltInFixers();
+        $fixerFactory->registerBuiltInFixers();
 
-            /** @var array<int, string> $builtInFixerNames */
-            $builtInFixerNames = \array_values(\array_map(static function (Fixer\FixerInterface $fixer): string {
-                return $fixer->getName();
-            }, $fixerFactory->getFixers()));
-        }
+        /** @var array<int, string> $builtInFixerNames */
+        $builtInFixerNames = \array_values(\array_map(static function (Fixer\FixerInterface $fixer): string {
+            return $fixer->getName();
+        }, $fixerFactory->getFixers()));
 
         return $builtInFixerNames;
     }


### PR DESCRIPTION
This PR

* [x] removes a `static` variable