### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order dataProvider annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.5.3...main`][2.5.3...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#255]), by [@localheinz]
+* Configured `phpdoc_order_by_value` fixer to order `@dataProvider` annotations by value ([#257]), by [@localheinz]
 
 ## [`2.5.3`][2.5.3]
 
@@ -187,6 +188,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#241]: https://github.com/ergebnis/php-cs-fixer-config/pull/241
 [#247]: https://github.com/ergebnis/php-cs-fixer-config/pull/247
 [#255]: https://github.com/ergebnis/php-cs-fixer-config/pull/255
+[#257]: https://github.com/ergebnis/php-cs-fixer-config/pull/257
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -302,6 +302,7 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',
+                'dataProvider',
             ],
         ],
         'phpdoc_return_self_reference' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -302,6 +302,7 @@ final class Php73 extends AbstractRuleSet
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',
+                'dataProvider',
             ],
         ],
         'phpdoc_return_self_reference' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -302,6 +302,7 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',
+                'dataProvider',
             ],
         ],
         'phpdoc_return_self_reference' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -308,6 +308,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',
+                'dataProvider',
             ],
         ],
         'phpdoc_return_self_reference' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -308,6 +308,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',
+                'dataProvider',
             ],
         ],
         'phpdoc_return_self_reference' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -308,6 +308,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'covers',
+                'dataProvider',
             ],
         ],
         'phpdoc_return_self_reference' => true,


### PR DESCRIPTION

This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@dataProvider` annotations by value

Follows #255.