### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order author annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`2.5.3...main`][2.5.3...main].
 * Updated `friendsofphp/php-cs-fixer` ([#255]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@dataProvider` annotations by value ([#257]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@uses` annotations by value ([#258]), by [@localheinz]
+* Configured `phpdoc_order_by_value` fixer to order `@author` annotations by value ([#259]), by [@localheinz]
 
 ## [`2.5.3`][2.5.3]
 
@@ -191,6 +192,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#255]: https://github.com/ergebnis/php-cs-fixer-config/pull/255
 [#257]: https://github.com/ergebnis/php-cs-fixer-config/pull/257
 [#258]: https://github.com/ergebnis/php-cs-fixer-config/pull/258
+[#259]: https://github.com/ergebnis/php-cs-fixer-config/pull/259
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -301,6 +301,7 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
+                'author',
                 'covers',
                 'dataProvider',
                 'uses',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -301,6 +301,7 @@ final class Php73 extends AbstractRuleSet
         'phpdoc_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
+                'author',
                 'covers',
                 'dataProvider',
                 'uses',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -301,6 +301,7 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
+                'author',
                 'covers',
                 'dataProvider',
                 'uses',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -307,6 +307,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
+                'author',
                 'covers',
                 'dataProvider',
                 'uses',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -307,6 +307,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'phpdoc_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
+                'author',
                 'covers',
                 'dataProvider',
                 'uses',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -307,6 +307,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_order' => true,
         'phpdoc_order_by_value' => [
             'annotations' => [
+                'author',
                 'covers',
                 'dataProvider',
                 'uses',


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@author` annotations by value

Follows #255.