### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order depends annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`2.5.3...main`][2.5.3...main].
 * Configured `phpdoc_order_by_value` fixer to order `@uses` annotations by value ([#258]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@author` annotations by value ([#259]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@coversNothing` annotations by value ([#260]), by [@localheinz]
+* Configured `phpdoc_order_by_value` fixer to order `@depends` annotations by value ([#261]), by [@localheinz]
 
 ## [`2.5.3`][2.5.3]
 
@@ -195,6 +196,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#258]: https://github.com/ergebnis/php-cs-fixer-config/pull/258
 [#259]: https://github.com/ergebnis/php-cs-fixer-config/pull/259
 [#260]: https://github.com/ergebnis/php-cs-fixer-config/pull/260
+[#261]: https://github.com/ergebnis/php-cs-fixer-config/pull/261
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -305,6 +305,7 @@ final class Php71 extends AbstractRuleSet
                 'covers',
                 'coversNothing',
                 'dataProvider',
+                'depends',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -305,6 +305,7 @@ final class Php73 extends AbstractRuleSet
                 'covers',
                 'coversNothing',
                 'dataProvider',
+                'depends',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -305,6 +305,7 @@ final class Php74 extends AbstractRuleSet
                 'covers',
                 'coversNothing',
                 'dataProvider',
+                'depends',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -311,6 +311,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'covers',
                 'coversNothing',
                 'dataProvider',
+                'depends',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -311,6 +311,7 @@ final class Php73Test extends AbstractRuleSetTestCase
                 'covers',
                 'coversNothing',
                 'dataProvider',
+                'depends',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -311,6 +311,7 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'covers',
                 'coversNothing',
                 'dataProvider',
+                'depends',
                 'uses',
             ],
         ],


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@depends` annotations by value

Follows #255.