### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order group annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`2.5.3...main`][2.5.3...main].
 * Configured `phpdoc_order_by_value` fixer to order `@author` annotations by value ([#259]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@coversNothing` annotations by value ([#260]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@depends` annotations by value ([#261]), by [@localheinz]
+* Configured `phpdoc_order_by_value` fixer to order `@group` annotations by value ([#262]), by [@localheinz]
 
 ## [`2.5.3`][2.5.3]
 
@@ -197,6 +198,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#259]: https://github.com/ergebnis/php-cs-fixer-config/pull/259
 [#260]: https://github.com/ergebnis/php-cs-fixer-config/pull/260
 [#261]: https://github.com/ergebnis/php-cs-fixer-config/pull/261
+[#262]: https://github.com/ergebnis/php-cs-fixer-config/pull/262
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -306,6 +306,7 @@ final class Php71 extends AbstractRuleSet
                 'coversNothing',
                 'dataProvider',
                 'depends',
+                'group',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -306,6 +306,7 @@ final class Php73 extends AbstractRuleSet
                 'coversNothing',
                 'dataProvider',
                 'depends',
+                'group',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -306,6 +306,7 @@ final class Php74 extends AbstractRuleSet
                 'coversNothing',
                 'dataProvider',
                 'depends',
+                'group',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -312,6 +312,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'coversNothing',
                 'dataProvider',
                 'depends',
+                'group',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -312,6 +312,7 @@ final class Php73Test extends AbstractRuleSetTestCase
                 'coversNothing',
                 'dataProvider',
                 'depends',
+                'group',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -312,6 +312,7 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'coversNothing',
                 'dataProvider',
                 'depends',
+                'group',
                 'uses',
             ],
         ],


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@group` annotations by value

Follows #255.