### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order requires annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`2.5.3...main`][2.5.3...main].
 * Configured `phpdoc_order_by_value` fixer to order `@depends` annotations by value ([#261]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@group` annotations by value ([#262]), by [@localheinz]
 * Configured `phpdoc_order_by_value` fixer to order `@internal` annotations by value ([#263]), by [@localheinz]
+* Configured `phpdoc_order_by_value` fixer to order `@requires` annotations by value ([#264]), by [@localheinz]
 
 ## [`2.5.3`][2.5.3]
 
@@ -201,6 +202,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#261]: https://github.com/ergebnis/php-cs-fixer-config/pull/261
 [#262]: https://github.com/ergebnis/php-cs-fixer-config/pull/262
 [#263]: https://github.com/ergebnis/php-cs-fixer-config/pull/263
+[#264]: https://github.com/ergebnis/php-cs-fixer-config/pull/264
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -308,6 +308,7 @@ final class Php71 extends AbstractRuleSet
                 'depends',
                 'group',
                 'internal',
+                'requires',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -308,6 +308,7 @@ final class Php73 extends AbstractRuleSet
                 'depends',
                 'group',
                 'internal',
+                'requires',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -308,6 +308,7 @@ final class Php74 extends AbstractRuleSet
                 'depends',
                 'group',
                 'internal',
+                'requires',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -314,6 +314,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'depends',
                 'group',
                 'internal',
+                'requires',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -314,6 +314,7 @@ final class Php73Test extends AbstractRuleSetTestCase
                 'depends',
                 'group',
                 'internal',
+                'requires',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -314,6 +314,7 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'depends',
                 'group',
                 'internal',
+                'requires',
                 'uses',
             ],
         ],


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@requires` annotations by value

Follows #255.