### PR TITLE
Fix: Do not use deprecated RuleSet

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,21 +25,3 @@ parameters:
 			count: 1
 			path: test/Unit/RuleSet/AbstractRuleSetTestCase.php
 
-		-
-			message:
-				"""
-					#^Call to deprecated method create\\(\\) of class PhpCsFixer\\\\RuleSet\\\\RuleSet\\:
-					will be removed in 3\\.0 Use the constructor\\.$#
-				"""
-			count: 1
-			path: test/Unit/RuleSet/AbstractRuleSetTestCase.php
-
-		-
-			message:
-				"""
-					#^Call to method create\\(\\) of deprecated class PhpCsFixer\\\\RuleSet\\\\RuleSet\\:
-					will be removed in 3\\.0, use \\\\PhpCsFixer\\\\RuleSet\\\\RuleSet$#
-				"""
-			count: 1
-			path: test/Unit/RuleSet/AbstractRuleSetTestCase.php
-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,24 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
   <file src="test/Unit/RuleSet/AbstractRuleSetTestCase.php">
-    <DeprecatedClass occurrences="1">
-      <code>RuleSet::create($rules)</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="1">
-      <code>RuleSet::create($rules)</code>
-    </DeprecatedMethod>
     <InternalClass occurrences="2">
       <code>FixerFactory::create()</code>
-      <code>RuleSet::create($rules)</code>
+      <code>new RuleSet\RuleSet($rules)</code>
     </InternalClass>
     <InternalMethod occurrences="4">
       <code>FixerFactory::create()</code>
-      <code>RuleSet::create($rules)</code>
       <code>getFixers</code>
+      <code>getRules</code>
       <code>registerBuiltInFixers</code>
     </InternalMethod>
-    <MixedMethodCall occurrences="1">
-      <code>getRules</code>
-    </MixedMethodCall>
   </file>
 </files>

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -279,8 +279,10 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
             return true;
         }, self::createRuleSet()->rules());
 
+        $ruleSet = new RuleSet\RuleSet($rules);
+
         /** @var array<string, Fixer\FixerInterface> $fixers */
-        $fixers = RuleSet::create($rules)->getRules();
+        $fixers = $ruleSet->getRules();
 
         return \array_keys($fixers);
     }


### PR DESCRIPTION
This PR

* [x] stops using the deprecated `RuleSet`
* [x] runs `make static-code-analysis-baseline

Follows #255.