### PR TITLE
Enhancement: Enable array_push fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.6.1...main`][2.6.1...main].
 
+### Changed
+
+* Enabled `array_push` fixer ([#279]), by [@localheinz]
+
 ## [`2.6.1`][2.6.1]
 
 For a full diff see [`2.6.0...2.6.1`][2.6.0...2.6.1].
@@ -222,6 +226,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#264]: https://github.com/ergebnis/php-cs-fixer-config/pull/264
 [#265]: https://github.com/ergebnis/php-cs-fixer-config/pull/265
 [#276]: https://github.com/ergebnis/php-cs-fixer-config/pull/276
+[#279]: https://github.com/ergebnis/php-cs-fixer-config/pull/279
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -24,7 +24,7 @@ final class Php71 extends AbstractRuleSet
             'comment_type' => 'all_multiline',
         ],
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -24,7 +24,7 @@ final class Php73 extends AbstractRuleSet
             'comment_type' => 'all_multiline',
         ],
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -24,7 +24,7 @@ final class Php74 extends AbstractRuleSet
             'comment_type' => 'all_multiline',
         ],
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -30,7 +30,7 @@ final class Php71Test extends AbstractRuleSetTestCase
             'comment_type' => 'all_multiline',
         ],
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -30,7 +30,7 @@ final class Php73Test extends AbstractRuleSetTestCase
             'comment_type' => 'all_multiline',
         ],
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -30,7 +30,7 @@ final class Php74Test extends AbstractRuleSetTestCase
             'comment_type' => 'all_multiline',
         ],
         'array_indentation' => true,
-        'array_push' => false,
+        'array_push' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],


### PR DESCRIPTION
This PR

* [x] enables the `array_push` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/alias/array_push.rst.