### PR TITLE
Enhancement: Enable clean_namespace fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 ### Changed
 
 * Enabled `array_push` fixer ([#279]), by [@localheinz]
+* Enabled `clean_namespace` fixer ([#280]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -227,6 +228,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#265]: https://github.com/ergebnis/php-cs-fixer-config/pull/265
 [#276]: https://github.com/ergebnis/php-cs-fixer-config/pull/276
 [#279]: https://github.com/ergebnis/php-cs-fixer-config/pull/279
+[#280]: https://github.com/ergebnis/php-cs-fixer-config/pull/280
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -69,7 +69,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'class_definition' => true,
         'class_keyword_remove' => false,
-        'clean_namespace' => false,
+        'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'combine_nested_dirname' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -69,7 +69,7 @@ final class Php73 extends AbstractRuleSet
         ],
         'class_definition' => true,
         'class_keyword_remove' => false,
-        'clean_namespace' => false,
+        'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'combine_nested_dirname' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -69,7 +69,7 @@ final class Php74 extends AbstractRuleSet
         ],
         'class_definition' => true,
         'class_keyword_remove' => false,
-        'clean_namespace' => false,
+        'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'combine_nested_dirname' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -75,7 +75,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'class_definition' => true,
         'class_keyword_remove' => false,
-        'clean_namespace' => false,
+        'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'combine_nested_dirname' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -75,7 +75,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         ],
         'class_definition' => true,
         'class_keyword_remove' => false,
-        'clean_namespace' => false,
+        'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'combine_nested_dirname' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -75,7 +75,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         ],
         'class_definition' => true,
         'class_keyword_remove' => false,
-        'clean_namespace' => false,
+        'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'combine_nested_dirname' => true,


### PR DESCRIPTION
This PR

* [x] enables the `clean_namespace ` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/namespace_notation/clean_namespace.rst.