### PR TITLE
Enhancement: Enable lambda_not_used_import fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 
 * Enabled `array_push` fixer ([#279]), by [@localheinz]
 * Enabled `clean_namespace` fixer ([#280]), by [@localheinz]
+* Enabled `lambda_not_used_import` fixer ([#281]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -229,6 +230,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#276]: https://github.com/ergebnis/php-cs-fixer-config/pull/276
 [#279]: https://github.com/ergebnis/php-cs-fixer-config/pull/279
 [#280]: https://github.com/ergebnis/php-cs-fixer-config/pull/280
+[#281]: https://github.com/ergebnis/php-cs-fixer-config/pull/281
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -146,7 +146,7 @@ final class Php71 extends AbstractRuleSet
         ],
         'indentation_type' => true,
         'is_null' => true,
-        'lambda_not_used_import' => false,
+        'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -146,7 +146,7 @@ final class Php73 extends AbstractRuleSet
         ],
         'indentation_type' => true,
         'is_null' => true,
-        'lambda_not_used_import' => false,
+        'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -146,7 +146,7 @@ final class Php74 extends AbstractRuleSet
         ],
         'indentation_type' => true,
         'is_null' => true,
-        'lambda_not_used_import' => false,
+        'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -152,7 +152,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         ],
         'indentation_type' => true,
         'is_null' => true,
-        'lambda_not_used_import' => false,
+        'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -152,7 +152,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         ],
         'indentation_type' => true,
         'is_null' => true,
-        'lambda_not_used_import' => false,
+        'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -152,7 +152,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         ],
         'indentation_type' => true,
         'is_null' => true,
-        'lambda_not_used_import' => false,
+        'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => [


### PR DESCRIPTION
This PR

* [x] enables the `lambda_not_used_import` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/function_notation/lambda_not_used_import.rst.