### PR TITLE
Enhancement: Enable no_alias_language_construct_call fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `array_push` fixer ([#279]), by [@localheinz]
 * Enabled `clean_namespace` fixer ([#280]), by [@localheinz]
 * Enabled `lambda_not_used_import` fixer ([#281]), by [@localheinz]
+* Enabled `no_alias_language_construct_call` fixer ([#282]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -231,6 +232,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#279]: https://github.com/ergebnis/php-cs-fixer-config/pull/279
 [#280]: https://github.com/ergebnis/php-cs-fixer-config/pull/280
 [#281]: https://github.com/ergebnis/php-cs-fixer-config/pull/281
+[#282]: https://github.com/ergebnis/php-cs-fixer-config/pull/282
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -175,7 +175,7 @@ final class Php71 extends AbstractRuleSet
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alias_language_construct_call' => false,
+        'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -175,7 +175,7 @@ final class Php73 extends AbstractRuleSet
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alias_language_construct_call' => false,
+        'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -175,7 +175,7 @@ final class Php74 extends AbstractRuleSet
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alias_language_construct_call' => false,
+        'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -181,7 +181,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alias_language_construct_call' => false,
+        'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -181,7 +181,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alias_language_construct_call' => false,
+        'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -181,7 +181,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'native_function_type_declaration_casing' => true,
         'new_with_braces' => true,
         'no_alias_functions' => true,
-        'no_alias_language_construct_call' => false,
+        'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_alias_language_construct_call` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/alias/no_alias_language_construct_call.rst.