### PR TITLE
Enhancement: Enable no_trailing_whitespace_in_string fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `clean_namespace` fixer ([#280]), by [@localheinz]
 * Enabled `lambda_not_used_import` fixer ([#281]), by [@localheinz]
 * Enabled `no_alias_language_construct_call` fixer ([#282]), by [@localheinz]
+* Enabled `no_trailing_whitespace_in_string` fixer ([#283]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -227,7 +227,7 @@ final class Php71 extends AbstractRuleSet
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -227,7 +227,7 @@ final class Php73 extends AbstractRuleSet
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -227,7 +227,7 @@ final class Php74 extends AbstractRuleSet
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -233,7 +233,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -233,7 +233,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -233,7 +233,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_trailing_comma_in_singleline_array' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
-        'no_trailing_whitespace_in_string' => false,
+        'no_trailing_whitespace_in_string' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unneeded_curly_braces' => true,
         'no_unneeded_final_method' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_trailing_whitespace_in_string` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/string_notation/no_trailing_whitespace_in_string.rst.