### PR TITLE
Enhancement: Enable no_useless_sprintf fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `lambda_not_used_import` fixer ([#281]), by [@localheinz]
 * Enabled `no_alias_language_construct_call` fixer ([#282]), by [@localheinz]
 * Enabled `no_trailing_whitespace_in_string` fixer ([#283]), by [@localheinz]
+* Enabled `no_useless_sprintf` fixer ([#284]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -234,6 +235,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#280]: https://github.com/ergebnis/php-cs-fixer-config/pull/280
 [#281]: https://github.com/ergebnis/php-cs-fixer-config/pull/281
 [#282]: https://github.com/ergebnis/php-cs-fixer-config/pull/282
+[#283]: https://github.com/ergebnis/php-cs-fixer-config/pull/283
+[#284]: https://github.com/ergebnis/php-cs-fixer-config/pull/284
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -237,7 +237,7 @@ final class Php71 extends AbstractRuleSet
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -237,7 +237,7 @@ final class Php73 extends AbstractRuleSet
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -237,7 +237,7 @@ final class Php74 extends AbstractRuleSet
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -243,7 +243,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -243,7 +243,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -243,7 +243,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_unused_imports' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'no_useless_sprintf' => false,
+        'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => true,
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,


### PR DESCRIPTION
This PR

* [x] enables the `no_useless_sprintf` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/function_notation/no_useless_sprintf.rst.