### PR TITLE
Enhancement: Enable and configure operator_linebreak fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `no_alias_language_construct_call` fixer ([#282]), by [@localheinz]
 * Enabled `no_trailing_whitespace_in_string` fixer ([#283]), by [@localheinz]
 * Enabled `no_useless_sprintf` fixer ([#284]), by [@localheinz]
+* Enabled and configured `operator_linebreak` fixer ([#285]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -237,6 +238,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#282]: https://github.com/ergebnis/php-cs-fixer-config/pull/282
 [#283]: https://github.com/ergebnis/php-cs-fixer-config/pull/283
 [#284]: https://github.com/ergebnis/php-cs-fixer-config/pull/284
+[#285]: https://github.com/ergebnis/php-cs-fixer-config/pull/285
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -246,7 +246,10 @@ final class Php71 extends AbstractRuleSet
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -246,7 +246,10 @@ final class Php73 extends AbstractRuleSet
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -246,7 +246,10 @@ final class Php74 extends AbstractRuleSet
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -252,7 +252,10 @@ final class Php71Test extends AbstractRuleSetTestCase
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -252,7 +252,10 @@ final class Php73Test extends AbstractRuleSetTestCase
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -252,7 +252,10 @@ final class Php74Test extends AbstractRuleSetTestCase
         'not_operator_with_successor_space' => false,
         'nullable_type_declaration_for_default_null_value' => true,
         'object_operator_without_whitespace' => true,
-        'operator_linebreak' => false,
+        'operator_linebreak' => [
+            'only_booleans' => true,
+            'position' => 'beginning',
+        ],
         'ordered_class_elements' => true,
         'ordered_imports' => [
             'imports_order' => [


### PR DESCRIPTION
This PR

* [x] enables and configures the `operator_linebreak` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/operator/operator_linebreak.rst.