### PR TITLE
Enhancement: Enable and configure phpdoc_inline_tag_normalizer fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `no_trailing_whitespace_in_string` fixer ([#283]), by [@localheinz]
 * Enabled `no_useless_sprintf` fixer ([#284]), by [@localheinz]
 * Enabled and configured `operator_linebreak` fixer ([#285]), by [@localheinz]
+* Enabled and configured `phpdoc_inline_tag_normalizer` fixer ([#286]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -239,6 +240,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#283]: https://github.com/ergebnis/php-cs-fixer-config/pull/283
 [#284]: https://github.com/ergebnis/php-cs-fixer-config/pull/284
 [#285]: https://github.com/ergebnis/php-cs-fixer-config/pull/285
+[#286]: https://github.com/ergebnis/php-cs-fixer-config/pull/286
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -300,7 +300,19 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag_normalizer' => false,
+        'phpdoc_inline_tag_normalizer' => [
+            'tags' => [
+                'example',
+                'id',
+                'inheritdoc',
+                'inheritdocs',
+                'internal',
+                'link',
+                'source',
+                'toc',
+                'tutorial',
+            ],
+        ],
         'phpdoc_line_span' => [
             'const' => 'multi',
             'method' => 'multi',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -300,7 +300,19 @@ final class Php73 extends AbstractRuleSet
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag_normalizer' => false,
+        'phpdoc_inline_tag_normalizer' => [
+            'tags' => [
+                'example',
+                'id',
+                'inheritdoc',
+                'inheritdocs',
+                'internal',
+                'link',
+                'source',
+                'toc',
+                'tutorial',
+            ],
+        ],
         'phpdoc_line_span' => [
             'const' => 'multi',
             'method' => 'multi',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -300,7 +300,19 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag_normalizer' => false,
+        'phpdoc_inline_tag_normalizer' => [
+            'tags' => [
+                'example',
+                'id',
+                'inheritdoc',
+                'inheritdocs',
+                'internal',
+                'link',
+                'source',
+                'toc',
+                'tutorial',
+            ],
+        ],
         'phpdoc_line_span' => [
             'const' => 'multi',
             'method' => 'multi',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -306,7 +306,19 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag_normalizer' => false,
+        'phpdoc_inline_tag_normalizer' => [
+            'tags' => [
+                'example',
+                'id',
+                'inheritdoc',
+                'inheritdocs',
+                'internal',
+                'link',
+                'source',
+                'toc',
+                'tutorial',
+            ],
+        ],
         'phpdoc_line_span' => [
             'const' => 'multi',
             'method' => 'multi',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -306,7 +306,19 @@ final class Php73Test extends AbstractRuleSetTestCase
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag_normalizer' => false,
+        'phpdoc_inline_tag_normalizer' => [
+            'tags' => [
+                'example',
+                'id',
+                'inheritdoc',
+                'inheritdocs',
+                'internal',
+                'link',
+                'source',
+                'toc',
+                'tutorial',
+            ],
+        ],
         'phpdoc_line_span' => [
             'const' => 'multi',
             'method' => 'multi',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -306,7 +306,19 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_align' => true,
         'phpdoc_annotation_without_dot' => true,
         'phpdoc_indent' => true,
-        'phpdoc_inline_tag_normalizer' => false,
+        'phpdoc_inline_tag_normalizer' => [
+            'tags' => [
+                'example',
+                'id',
+                'inheritdoc',
+                'inheritdocs',
+                'internal',
+                'link',
+                'source',
+                'toc',
+                'tutorial',
+            ],
+        ],
         'phpdoc_line_span' => [
             'const' => 'multi',
             'method' => 'multi',


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_inline_tag_normalizer` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/phpdoc/phpdoc_inline_tag_normalizer.rst.