### PR TITLE
Enhancement: Enable and configure phpdoc_tag_casing fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `no_useless_sprintf` fixer ([#284]), by [@localheinz]
 * Enabled and configured `operator_linebreak` fixer ([#285]), by [@localheinz]
 * Enabled and configured `phpdoc_inline_tag_normalizer` fixer ([#286]), by [@localheinz]
+* Enabled and configured `phpdoc_tag_casing` fixer ([#287]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -241,6 +242,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#284]: https://github.com/ergebnis/php-cs-fixer-config/pull/284
 [#285]: https://github.com/ergebnis/php-cs-fixer-config/pull/285
 [#286]: https://github.com/ergebnis/php-cs-fixer-config/pull/286
+[#287]: https://github.com/ergebnis/php-cs-fixer-config/pull/287
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -342,7 +342,11 @@ final class Php71 extends AbstractRuleSet
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => [
+            'tags' => [
+                'inheritDoc',
+            ],
+        ],
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritdoc' => 'inline',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -342,7 +342,11 @@ final class Php73 extends AbstractRuleSet
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => [
+            'tags' => [
+                'inheritDoc',
+            ],
+        ],
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritdoc' => 'inline',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -342,7 +342,11 @@ final class Php74 extends AbstractRuleSet
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => [
+            'tags' => [
+                'inheritDoc',
+            ],
+        ],
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritdoc' => 'inline',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -348,7 +348,11 @@ final class Php71Test extends AbstractRuleSetTestCase
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => [
+            'tags' => [
+                'inheritDoc',
+            ],
+        ],
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritdoc' => 'inline',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -348,7 +348,11 @@ final class Php73Test extends AbstractRuleSetTestCase
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => [
+            'tags' => [
+                'inheritDoc',
+            ],
+        ],
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritdoc' => 'inline',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -348,7 +348,11 @@ final class Php74Test extends AbstractRuleSetTestCase
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_summary' => true,
-        'phpdoc_tag_casing' => false,
+        'phpdoc_tag_casing' => [
+            'tags' => [
+                'inheritDoc',
+            ],
+        ],
         'phpdoc_tag_type' => [
             'tags' => [
                 'inheritdoc' => 'inline',


### PR DESCRIPTION
This PR

* [x] enables and configures the `phpdoc_tag_casing` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/phpdoc/phpdoc_tag_casing.rst.