### PR TITLE
Enhancement: Enable switch_continue_to_break fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled and configured `phpdoc_tag_casing` fixer ([#287]), by [@localheinz]
 * Enabled `regular_callable_call` fixer ([#288]), by [@localheinz]
 * Enabled and configured `single_space_after_construct` fixer ([#289]), by [@localheinz]
+* Enabled `switch_continue_to_break` fixer ([#290]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -247,6 +248,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#287]: https://github.com/ergebnis/php-cs-fixer-config/pull/287
 [#288]: https://github.com/ergebnis/php-cs-fixer-config/pull/288
 [#289]: https://github.com/ergebnis/php-cs-fixer-config/pull/289
+[#290]: https://github.com/ergebnis/php-cs-fixer-config/pull/290
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -464,7 +464,7 @@ final class Php71 extends AbstractRuleSet
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
-        'switch_continue_to_break' => false,
+        'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => false,
         'ternary_to_null_coalescing' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -464,7 +464,7 @@ final class Php73 extends AbstractRuleSet
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
-        'switch_continue_to_break' => false,
+        'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => false,
         'ternary_to_null_coalescing' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -464,7 +464,7 @@ final class Php74 extends AbstractRuleSet
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
-        'switch_continue_to_break' => false,
+        'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => false,
         'ternary_to_null_coalescing' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -470,7 +470,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
-        'switch_continue_to_break' => false,
+        'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => false,
         'ternary_to_null_coalescing' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -470,7 +470,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
-        'switch_continue_to_break' => false,
+        'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => false,
         'ternary_to_null_coalescing' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -470,7 +470,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,
-        'switch_continue_to_break' => false,
+        'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => false,
         'ternary_to_null_coalescing' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `switch_continue_to_break` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/control_structure/switch_continue_to_break.rst.