### PR TITLE
Enhancement: Enable ternary_to_elvis_operator fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.6.1...main`][2.6.1...main].
+For a full diff see [`2.7.0...main`][2.7.0...main].
+
+## [`2.7.0`][2.7.0]
+
+For a full diff see [`2.6.1...2.7.0`][2.6.1...2.7.0].
 
 ### Changed
 
@@ -22,6 +26,7 @@ For a full diff see [`2.6.1...main`][2.6.1...main].
 * Enabled `regular_callable_call` fixer ([#288]), by [@localheinz]
 * Enabled and configured `single_space_after_construct` fixer ([#289]), by [@localheinz]
 * Enabled `switch_continue_to_break` fixer ([#290]), by [@localheinz]
+* Enabled `ternary_to_elvis_operator` fixer ([#291]), by [@localheinz]
 
 ## [`2.6.1`][2.6.1]
 
@@ -190,6 +195,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.5.3]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.5.3
 [2.6.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.6.0
 [2.6.1]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.6.1
+[2.7.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/2.7.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -209,7 +215,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [2.5.2...2.5.3]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.5.2...2.5.3
 [2.5.3...2.6.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.5.3...2.6.0
 [2.6.0...2.6.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.6.0...2.6.1
-[2.6.1...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.6.1...main
+[2.6.1...2.7.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.6.1...2.7.0
+[2.7.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/2.7.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -249,6 +256,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#288]: https://github.com/ergebnis/php-cs-fixer-config/pull/288
 [#289]: https://github.com/ergebnis/php-cs-fixer-config/pull/289
 [#290]: https://github.com/ergebnis/php-cs-fixer-config/pull/290
+[#291]: https://github.com/ergebnis/php-cs-fixer-config/pull/291
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -466,7 +466,7 @@ final class Php71 extends AbstractRuleSet
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -466,7 +466,7 @@ final class Php73 extends AbstractRuleSet
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -466,7 +466,7 @@ final class Php74 extends AbstractRuleSet
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -472,7 +472,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -472,7 +472,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -472,7 +472,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'switch_case_space' => true,
         'switch_continue_to_break' => true,
         'ternary_operator_spaces' => true,
-        'ternary_to_elvis_operator' => false,
+        'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `ternary_to_elvis_operator` fixer

Follows #273.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.0/doc/rules/operator/ternary_to_elvis_operator.rst.