### PR TITLE
Enhancement: Enable and configure php_unit_test_case_static_method_calls fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.8.0...main`][2.8.0...main].
 
+### Changed
+
+* Enabled and configured `php_unit_test_case_static_method_calls` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#301]), by [@localheinz]
+*
 ## [`2.8.0`][2.8.0]
 
 For a full diff see [`2.7.0...2.8.0`][2.7.0...2.8.0].
@@ -268,6 +272,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#290]: https://github.com/ergebnis/php-cs-fixer-config/pull/290
 [#291]: https://github.com/ergebnis/php-cs-fixer-config/pull/291
 [#300]: https://github.com/ergebnis/php-cs-fixer-config/pull/300
+[#301]: https://github.com/ergebnis/php-cs-fixer-config/pull/301
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/PhpUnit.php
+++ b/src/RuleSet/PhpUnit.php
@@ -262,7 +262,9 @@ final class PhpUnit extends AbstractRuleSet
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => false,
-        'php_unit_test_case_static_method_calls' => false,
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'this',
+        ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => false,
         'phpdoc_align' => true,

--- a/test/Unit/RuleSet/PhpUnitTest.php
+++ b/test/Unit/RuleSet/PhpUnitTest.php
@@ -265,7 +265,9 @@ final class PhpUnitTest extends AbstractRuleSetTestCase
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => false,
-        'php_unit_test_case_static_method_calls' => false,
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'this',
+        ],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => false,
         'phpdoc_align' => true,


### PR DESCRIPTION
This PR

* [x] enables and configures the `php_unit_test_case_static_method_calls` fixer for the `PhpUnit` rule set

Follows https://github.com/sebastianbergmann/phpunit/pull/4553.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst.