### PR TITLE
Enhancement: Configure phpdoc_order_by_value fixer to order throws annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.8.0...main`][2.8.0...main].
 ### Changed
 
 * Enabled and configured `php_unit_test_case_static_method_calls` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#301]), by [@localheinz]
+* Configured `phpdoc_order_by_value` fixer to order `@throws` annotations ([#302]), by [@localheinz]
 * Enabled `php_unit_set_up_tear_down_visibility` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#303]), by [@localheinz]
 * Enabled `allow_single_line_anonymous_class_with_empty_body` option for `braces` fixer ([#306]), by [@localheinz]
 
@@ -280,6 +281,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#291]: https://github.com/ergebnis/php-cs-fixer-config/pull/291
 [#300]: https://github.com/ergebnis/php-cs-fixer-config/pull/300
 [#301]: https://github.com/ergebnis/php-cs-fixer-config/pull/301
+[#302]: https://github.com/ergebnis/php-cs-fixer-config/pull/302
 [#303]: https://github.com/ergebnis/php-cs-fixer-config/pull/303
 [#304]: https://github.com/ergebnis/php-cs-fixer-config/pull/304
 [#306]: https://github.com/ergebnis/php-cs-fixer-config/pull/306

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -336,6 +336,7 @@ final class Php71 extends AbstractRuleSet
                 'group',
                 'internal',
                 'requires',
+                'throws',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -336,6 +336,7 @@ final class Php73 extends AbstractRuleSet
                 'group',
                 'internal',
                 'requires',
+                'throws',
                 'uses',
             ],
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -336,6 +336,7 @@ final class Php74 extends AbstractRuleSet
                 'group',
                 'internal',
                 'requires',
+                'throws',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -342,6 +342,7 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'group',
                 'internal',
                 'requires',
+                'throws',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -342,6 +342,7 @@ final class Php73Test extends AbstractRuleSetTestCase
                 'group',
                 'internal',
                 'requires',
+                'throws',
                 'uses',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -342,6 +342,7 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'group',
                 'internal',
                 'requires',
+                'throws',
                 'uses',
             ],
         ],


### PR DESCRIPTION
This PR

* [x] configures the `phpdoc_order_by_value` fixer to order `@throws` annotations

Follows #309.
