### PR TITLE
Enhancement: Enable php_unit_set_up_tear_down_visibility fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ For a full diff see [`2.8.0...main`][2.8.0...main].
 ### Changed
 
 * Enabled and configured `php_unit_test_case_static_method_calls` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#301]), by [@localheinz]
-*
+* Enabled `php_unit_set_up_tear_down_visibility` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#303]), by [@localheinz]
+
 ## [`2.8.0`][2.8.0]
 
 For a full diff see [`2.7.0...2.8.0`][2.7.0...2.8.0].
@@ -273,6 +274,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#291]: https://github.com/ergebnis/php-cs-fixer-config/pull/291
 [#300]: https://github.com/ergebnis/php-cs-fixer-config/pull/300
 [#301]: https://github.com/ergebnis/php-cs-fixer-config/pull/301
+[#303]: https://github.com/ergebnis/php-cs-fixer-config/pull/303
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/PhpUnit.php
+++ b/src/RuleSet/PhpUnit.php
@@ -258,7 +258,7 @@ final class PhpUnit extends AbstractRuleSet
         'php_unit_mock_short_will_return' => false,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => false,

--- a/test/Unit/RuleSet/PhpUnitTest.php
+++ b/test/Unit/RuleSet/PhpUnitTest.php
@@ -261,7 +261,7 @@ final class PhpUnitTest extends AbstractRuleSetTestCase
         'php_unit_mock_short_will_return' => false,
         'php_unit_namespaced' => false,
         'php_unit_no_expectation_annotation' => false,
-        'php_unit_set_up_tear_down_visibility' => false,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => false,


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_set_up_tear_down_visibility` fixer for the `PhpUnit` rule set

Follows https://github.com/sebastianbergmann/phpunit/pull/4555.