### PR TITLE
Enhancement: Configure braces fixer to allow single-line anonymous classes with empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.8.0...main`][2.8.0...main].
 
 * Enabled and configured `php_unit_test_case_static_method_calls` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#301]), by [@localheinz]
 * Enabled `php_unit_set_up_tear_down_visibility` fixer for `Ergebnis\PhpCsFixer\Config\RuleSet\PhpUnit` ([#303]), by [@localheinz]
+* Enabled `allow_single_line_anonymous_class_with_empty_body` option for `braces` fixer ([#306]), by [@localheinz]
 
 ### Fixed
 
@@ -280,6 +281,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#301]: https://github.com/ergebnis/php-cs-fixer-config/pull/301
 [#303]: https://github.com/ergebnis/php-cs-fixer-config/pull/303
 [#304]: https://github.com/ergebnis/php-cs-fixer-config/pull/304
+[#306]: https://github.com/ergebnis/php-cs-fixer-config/pull/306
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -59,7 +59,9 @@ final class Php71 extends AbstractRuleSet
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -59,7 +59,9 @@ final class Php73 extends AbstractRuleSet
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -59,7 +59,9 @@ final class Php74 extends AbstractRuleSet
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -65,7 +65,9 @@ final class Php71Test extends AbstractRuleSetTestCase
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -65,7 +65,9 @@ final class Php73Test extends AbstractRuleSetTestCase
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -65,7 +65,9 @@ final class Php74Test extends AbstractRuleSetTestCase
                 'yield',
             ],
         ],
-        'braces' => true,
+        'braces' => [
+            'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [


### PR DESCRIPTION
This PR

* [x]  configures the `braces` fixer to allow single-line anonymous classes with empty body

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.2/doc/rules/basic/braces.rst.