### PR TITLE
Enhancement: Require ExplicitRuleSets only not to configure rule sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.9.0...main`][2.9.0...main].
 
-### Changed
+### Added
 
 * Added `Config\RuleSet\ExplicitRuleSet` marker interface for rule-sets that should  be configured explicitly ([#311]), by [@localheinz]
+
+### Changed
+
+* Required only implementations of `Config\RuleSet\ExplicitRuleSet` not to configure any rules for rule sets ([#313]), by [@localheinz]
 
 ## [`2.9.0`][2.9.0]
 
@@ -299,6 +303,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#309]: https://github.com/ergebnis/php-cs-fixer-config/pull/309
 [#310]: https://github.com/ergebnis/php-cs-fixer-config/pull/310
 [#311]: https://github.com/ergebnis/php-cs-fixer-config/pull/311
+[#313]: https://github.com/ergebnis/php-cs-fixer-config/pull/313
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/ExplicitRuleSet.php
+++ b/src/RuleSet/ExplicitRuleSet.php
@@ -15,6 +15,10 @@ namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
 /**
  * Marker interface for explicit rule sets.
+ *
+ * An explicit rule set:
+ *
+ * - does not configure any rules for rule sets (@see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/doc/ruleSets/index.rst)
  */
 interface ExplicitRuleSet
 {

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -48,21 +48,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         self::assertSame($this->targetPhpVersion, $ruleSet->targetPhpVersion());
     }
 
-    final public function testRuleSetDoesNotConfigureRuleSets(): void
-    {
-        $namesOfRulesThatAreConfigured = \array_keys(self::createRuleSet()->rules());
-
-        $namesOfRulesThatAreConfiguredAndReferenceRuleSets = \array_filter($namesOfRulesThatAreConfigured, static function (string $ruleName): bool {
-            return '@' === \mb_substr($ruleName, 0, 1);
-        });
-
-        self::assertEmpty($namesOfRulesThatAreConfiguredAndReferenceRuleSets, \sprintf(
-            "Failed asserting that rule set \"%s\" does not configure rule sets. Rule sets with names\n\n%s\n\nshould not be used.",
-            static::className(),
-            ' - ' . \implode("\n - ", $namesOfRulesThatAreConfiguredAndReferenceRuleSets)
-        ));
-    }
-
     final public function testRuleSetDoesNotConfigureRulesThatAreNotBuiltIn(): void
     {
         $namesOfRulesThatAreConfiguredAndNotBuiltIn = \array_diff(

--- a/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
+++ b/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
@@ -26,4 +26,19 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
 
         self::assertInstanceOf(Config\RuleSet\ExplicitRuleSet::class, $ruleSet);
     }
+
+    final public function testRuleSetDoesNotConfigureRuleSets(): void
+    {
+        $namesOfRulesThatAreConfigured = \array_keys(self::createRuleSet()->rules());
+
+        $namesOfRulesThatAreConfiguredAndReferenceRuleSets = \array_filter($namesOfRulesThatAreConfigured, static function (string $ruleName): bool {
+            return '@' === \mb_substr($ruleName, 0, 1);
+        });
+
+        self::assertEmpty($namesOfRulesThatAreConfiguredAndReferenceRuleSets, \sprintf(
+            "Failed asserting that rule set \"%s\" does not configure rule sets. Rule sets with names\n\n%s\n\nshould not be used.",
+            static::className(),
+            ' - ' . \implode("\n - ", $namesOfRulesThatAreConfiguredAndReferenceRuleSets)
+        ));
+    }
 }


### PR DESCRIPTION
This PR

* [x] requires only implementations of `ExplicitRuleSet` not to configure rules for rule sets