### PR TITLE
Fix: Do not use constants

### DIFF
--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
-use PhpCsFixer\Fixer;
-
 final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'ergebnis (PHP 7.1)';
@@ -455,9 +453,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'ordered_imports' => [
             'imports_order' => [
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                'class',
+                'const',
+                'function',
             ],
         ],
         'ordered_interfaces' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
-use PhpCsFixer\Fixer;
-
 final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'ergebnis (PHP 7.3)';
@@ -455,9 +453,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'ordered_imports' => [
             'imports_order' => [
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                'class',
+                'const',
+                'function',
             ],
         ],
         'ordered_interfaces' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
-use PhpCsFixer\Fixer;
-
 final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'ergebnis (PHP 7.4)';
@@ -455,9 +453,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'ordered_imports' => [
             'imports_order' => [
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                'class',
+                'const',
+                'function',
             ],
         ],
         'ordered_interfaces' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
-use PhpCsFixer\Fixer;
-
 /**
  * @internal
  *
@@ -461,9 +459,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
         ],
         'ordered_imports' => [
             'imports_order' => [
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                'class',
+                'const',
+                'function',
             ],
         ],
         'ordered_interfaces' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
-use PhpCsFixer\Fixer;
-
 /**
  * @internal
  *
@@ -461,9 +459,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         ],
         'ordered_imports' => [
             'imports_order' => [
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                'class',
+                'const',
+                'function',
             ],
         ],
         'ordered_interfaces' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
-use PhpCsFixer\Fixer;
-
 /**
  * @internal
  *
@@ -461,9 +459,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'ordered_imports' => [
             'imports_order' => [
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CLASS,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_CONST,
-                Fixer\Import\OrderedImportsFixer::IMPORT_TYPE_FUNCTION,
+                'class',
+                'const',
+                'function',
             ],
         ],
         'ordered_interfaces' => [


### PR DESCRIPTION
This PR

* [x] stops using constants from `friendsofphp/php-cs-fixer`