### PR TITLE
Fix: Do not configure rules using deprecated configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ For a full diff see [`2.9.0...main`][2.9.0...main].
 * Required only implementations of `Config\RuleSet\ExplicitRuleSet` not to configure any rules for rule sets ([#313]), by [@localheinz]
 * Required implementations of `Config\RuleSet\ExplicitRuleSet` to configure non-deprecated rules that are configurable with an explicit configuration when enabled ([#314]), by [@localheinz]
 
+### Fixed
+
+* Stopped configuring rules using deprecated configuration options ([#319]), by [@localheinz]
+
 ## [`2.9.0`][2.9.0]
 
 For a full diff see [`2.8.0...2.9.0`][2.8.0...2.9.0].
@@ -306,6 +310,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#311]: https://github.com/ergebnis/php-cs-fixer-config/pull/311
 [#313]: https://github.com/ergebnis/php-cs-fixer-config/pull/313
 [#314]: https://github.com/ergebnis/php-cs-fixer-config/pull/314
+[#319]: https://github.com/ergebnis/php-cs-fixer-config/pull/319
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -291,8 +291,8 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -276,9 +276,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -504,7 +504,6 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [
-            'case' => 'camel',
             'style' => 'prefix',
         ],
         'php_unit_test_case_static_method_calls' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -291,8 +291,8 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -504,7 +504,6 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [
-            'case' => 'camel',
             'style' => 'prefix',
         ],
         'php_unit_test_case_static_method_calls' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -276,9 +276,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -504,7 +504,6 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [
-            'case' => 'camel',
             'style' => 'prefix',
         ],
         'php_unit_test_case_static_method_calls' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -291,8 +291,8 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -276,9 +276,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/src/RuleSet/PhpUnit.php
+++ b/src/RuleSet/PhpUnit.php
@@ -142,7 +142,7 @@ final class PhpUnit extends AbstractRuleSet
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => false,
         'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -297,8 +297,8 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -510,7 +510,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [
-            'case' => 'camel',
             'style' => 'prefix',
         ],
         'php_unit_test_case_static_method_calls' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -282,9 +282,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -297,8 +297,8 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -510,7 +510,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [
-            'case' => 'camel',
             'style' => 'prefix',
         ],
         'php_unit_test_case_static_method_calls' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -282,9 +282,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -297,8 +297,8 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => true,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
             'keep_multiple_spaces_after_comma' => false,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
         'modernize_types_casting' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -282,9 +282,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'is_null' => [
-            'use_yoda_style' => true,
-        ],
+        'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,
         'linebreak_after_opening_tag' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -510,7 +510,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'php_unit_size_class' => false,
         'php_unit_strict' => false,
         'php_unit_test_annotation' => [
-            'case' => 'camel',
             'style' => 'prefix',
         ],
         'php_unit_test_case_static_method_calls' => [

--- a/test/Unit/RuleSet/PhpUnitTest.php
+++ b/test/Unit/RuleSet/PhpUnitTest.php
@@ -145,7 +145,7 @@ final class PhpUnitTest extends AbstractRuleSetTestCase
         'magic_method_casing' => true,
         'mb_str_functions' => false,
         'method_argument_space' => [
-            'ensure_fully_multiline' => true,
+            'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => false,
         'modernize_types_casting' => true,


### PR DESCRIPTION
This PR

* [x] asserts that rule sets do not configure rules using deprecated configuration options
* [ ] stops configuring rules using deprecated configuration options