### PR TITLE
Fix: Only require implementations of ExplicitRuleSet to configure every non-deprecated rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For a full diff see [`2.9.0...2.10.0`][2.9.0...2.10.0].
 * Required only implementations of `Config\RuleSet\ExplicitRuleSet` not to configure any rules for rule sets ([#313]), by [@localheinz]
 * Required implementations of `Config\RuleSet\ExplicitRuleSet` to configure non-deprecated rules that are configurable with an explicit configuration when enabled ([#314]), by [@localheinz]
 * Required implementations of `Config\RuleSet\ExplicitRuleSet` to configure non-deprecated rules that are configurable with all non-deprecated configuration options when enabled ([#320]), by [@localheinz]
+* Required only implementations of `Config\RuleSet\ExplicitRuleSet` to configure all non-deprecated rules ([#321]), by [@localheinz]
 
 ### Fixed
 
@@ -319,6 +320,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#314]: https://github.com/ergebnis/php-cs-fixer-config/pull/314
 [#319]: https://github.com/ergebnis/php-cs-fixer-config/pull/319
 [#320]: https://github.com/ergebnis/php-cs-fixer-config/pull/320
+[#321]: https://github.com/ergebnis/php-cs-fixer-config/pull/321
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/ExplicitRuleSet.php
+++ b/src/RuleSet/ExplicitRuleSet.php
@@ -20,6 +20,7 @@ namespace Ergebnis\PhpCsFixer\Config\RuleSet;
  *
  * - does not configure any rules for rule sets (@see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.17.3/doc/ruleSets/index.rst)
  * - configures a rule that can be configured with an explicit configuration when the rule is enabled
+ * - configures every rule that is not deprecated
  */
 interface ExplicitRuleSet
 {

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -77,20 +77,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         ));
     }
 
-    final public function testRuleSetConfiguresAllRulesThatAreNotDeprecated(): void
-    {
-        $namesOfRulesThatAreNotDeprecatedAndNotConfigured = \array_diff(
-            self::namesOfRulesThatAreBuiltInAndNotDeprecated(),
-            self::namesOfRulesThatAreConfigured()
-        );
-
-        self::assertEmpty($namesOfRulesThatAreNotDeprecatedAndNotConfigured, \sprintf(
-            "Failed asserting that rule set \"%s\" configures all non-deprecated fixers. Rules with the names\n\n%s\n\nare not configured.",
-            static::className(),
-            ' - ' . \implode("\n - ", $namesOfRulesThatAreNotDeprecatedAndNotConfigured)
-        ));
-    }
-
     final public function testRuleSetDoesNotConfigureRulesUsingDeprecatedConfigurationOptions(): void
     {
         $rules = self::createRuleSet()->rules();
@@ -320,7 +306,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     /**
      * @return array<int, string>
      */
-    private static function namesOfRulesThatAreConfigured(): array
+    final protected static function namesOfRulesThatAreConfigured(): array
     {
         /**
          * RuleSet\RuleSet::resolveSet() removes disabled fixers, to let's just enable them to make sure they are not removed.
@@ -356,16 +342,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     {
         return \array_keys(\array_filter(self::fixersThatAreBuiltIn(), static function (Fixer\FixerInterface $fixer): bool {
             return $fixer instanceof Fixer\DeprecatedFixerInterface;
-        }));
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private static function namesOfRulesThatAreBuiltInAndNotDeprecated(): array
-    {
-        return \array_keys(\array_filter(self::fixersThatAreBuiltIn(), static function (Fixer\FixerInterface $fixer): bool {
-            return !$fixer instanceof Fixer\DeprecatedFixerInterface;
         }));
     }
 }

--- a/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
+++ b/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
@@ -44,6 +44,20 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
         ));
     }
 
+    final public function testRuleSetConfiguresAllRulesThatAreNotDeprecated(): void
+    {
+        $namesOfRulesThatAreNotDeprecatedAndNotConfigured = \array_diff(
+            self::namesOfRulesThatAreBuiltInAndNotDeprecated(),
+            self::namesOfRulesThatAreConfigured()
+        );
+
+        self::assertEmpty($namesOfRulesThatAreNotDeprecatedAndNotConfigured, \sprintf(
+            "Failed asserting that rule set \"%s\" configures all non-deprecated fixers. Rules with the names\n\n%s\n\nare not configured.",
+            static::className(),
+            ' - ' . \implode("\n - ", $namesOfRulesThatAreNotDeprecatedAndNotConfigured)
+        ));
+    }
+
     final public function testRuleSetConfiguresAllRulesThatAreConfigurableAndNotDeprecatedWithAnExplicitConfigurationWithEveryOptionWhenTheyAreEnabled(): void
     {
         $rules = self::createRuleSet()->rules();
@@ -102,5 +116,18 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
             'Failed asserting that rule set "%s" configures configurable rules using all non-deprecated configuration options.',
             static::className()
         ));
+    }
+
+    /**
+     * @phpstan-return list<string>
+     * @psalm-return list<string>
+     *
+     * @return array<int, string>
+     */
+    private static function namesOfRulesThatAreBuiltInAndNotDeprecated(): array
+    {
+        return \array_keys(\array_filter(self::fixersThatAreBuiltIn(), static function (Fixer\FixerInterface $fixer): bool {
+            return !$fixer instanceof Fixer\DeprecatedFixerInterface;
+        }));
     }
 }


### PR DESCRIPTION
This PR

* [x] requires only implementations of `ExplicitRuleSet` to configure every non-deprecated rule