### PR TITLE
Enhancement: Return true when expected rule configuration is empty array

### DIFF
--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -108,12 +108,18 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
                     return $fixerOption instanceof FixerConfiguration\DeprecatedFixerOptionInterface;
                 });
 
-                return \array_diff_key(
+                $ruleConfigurationWithoutDeprecatedConfigurationOptions = \array_diff_key(
                     $ruleConfiguration,
                     \array_flip(\array_map(static function (FixerConfiguration\FixerOptionInterface $fixerOption): string {
                         return $fixerOption->getName();
                     }, $deprecatedConfigurationOptions))
                 );
+
+                if ([] === $ruleConfigurationWithoutDeprecatedConfigurationOptions) {
+                    return true;
+                }
+
+                return $ruleConfigurationWithoutDeprecatedConfigurationOptions;
             }, $namesOfRules, $rules)
         );
 


### PR DESCRIPTION
This PR

* [x] returns `true` when the expected rule configuration is an empty `array`