### PR TITLE
Fix: Do not use deprecated configuration for class_attributes_separation fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.13.0...main`][2.13.0...main].
 
+### Fixed
+
+* Stopped using deprecated configuration for `class_attributes_separation` fixer ([#354]), by [@localheinz]
+
 ## [`2.13.0`][2.13.0]
 
 For a full diff see [`2.12.1...2.13.0`][2.12.1...2.13.0].
@@ -377,6 +381,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#348]: https://github.com/ergebnis/php-cs-fixer-config/pull/348
 [#350]: https://github.com/ergebnis/php-cs-fixer-config/pull/350
 [#352]: https://github.com/ergebnis/php-cs-fixer-config/pull/352
+[#354]: https://github.com/ergebnis/php-cs-fixer-config/pull/354
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Laravel6.php
+++ b/src/RuleSet/Laravel6.php
@@ -45,7 +45,7 @@ final class Laravel6 extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -70,8 +70,8 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -70,8 +70,8 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -70,8 +70,8 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -70,8 +70,8 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -70,8 +70,8 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/PhpUnit.php
+++ b/src/RuleSet/PhpUnit.php
@@ -64,9 +64,9 @@ final class PhpUnit extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'const',
-                'method',
-                'property',
+                'const' => 'one',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => true,

--- a/test/Unit/RuleSet/Laravel6Test.php
+++ b/test/Unit/RuleSet/Laravel6Test.php
@@ -48,7 +48,7 @@ final class Laravel6Test extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -76,8 +76,8 @@ final class Php71Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -76,8 +76,8 @@ final class Php72Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -76,8 +76,8 @@ final class Php73Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -76,8 +76,8 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -76,8 +76,8 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
-                'method',
-                'property',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/PhpUnitTest.php
+++ b/test/Unit/RuleSet/PhpUnitTest.php
@@ -67,9 +67,9 @@ final class PhpUnitTest extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'const',
-                'method',
-                'property',
+                'const' => 'one',
+                'method' => 'one',
+                'property' => 'one',
             ],
         ],
         'class_definition' => true,


### PR DESCRIPTION
This pull request

* [x] stops using the deprecated configuration for the `class_attributes_separation` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5485.