### PR TITLE
Enhancement: Configure trailing_comma_in_multiline fixer to add trailing commas for arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.13.1...main`][2.13.1...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#400]), by [@dependabot]
+* Configured `trailing_comma_in_multiline` fixer to add trailing commas for arguments in `Php73`, `Php74`, and `Php80` rule sets ([#401]), by [@localheinz]
 
 ## [`2.13.1`][2.13.1]
 
@@ -395,6 +396,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#354]: https://github.com/ergebnis/php-cs-fixer-config/pull/354
 [#392]: https://github.com/ergebnis/php-cs-fixer-config/pull/392
 [#400]: https://github.com/ergebnis/php-cs-fixer-config/pull/400
+[#401]: https://github.com/ergebnis/php-cs-fixer-config/pull/401
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -1023,6 +1023,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'trailing_comma_in_multiline' => [
             'after_heredoc' => false,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -1023,6 +1023,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'trailing_comma_in_multiline' => [
             'after_heredoc' => false,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -1023,6 +1023,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'trailing_comma_in_multiline' => [
             'after_heredoc' => false,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -1029,6 +1029,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'trailing_comma_in_multiline' => [
             'after_heredoc' => false,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -1029,6 +1029,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'trailing_comma_in_multiline' => [
             'after_heredoc' => false,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -1029,6 +1029,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'trailing_comma_in_multiline' => [
             'after_heredoc' => false,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],


### PR DESCRIPTION
This pull request

* [x] configures the `trailing_comma_in_multiline` fixer to add trailing commas for arguments

Follows #400.