### PR TITLE
Enhancement: Configure trailing_comma_in_multiline fixer to add trailing commas for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.13.1...main`][2.13.1...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#400]), by [@dependabot]
 * Configured `trailing_comma_in_multiline` fixer to add trailing commas for arguments in `Php73`, `Php74`, and `Php80` rule sets ([#401]), by [@localheinz]
+* Configured `trailing_comma_in_multiline` fixer to add trailing commas for parameters in `Php80` rule set ([#404]), by [@localheinz]
 
 ## [`2.13.1`][2.13.1]
 
@@ -397,6 +398,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#392]: https://github.com/ergebnis/php-cs-fixer-config/pull/392
 [#400]: https://github.com/ergebnis/php-cs-fixer-config/pull/400
 [#401]: https://github.com/ergebnis/php-cs-fixer-config/pull/401
+[#404]: https://github.com/ergebnis/php-cs-fixer-config/pull/404
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -1025,6 +1025,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'elements' => [
                 'arguments',
                 'arrays',
+                'parameters',
             ],
         ],
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -1031,6 +1031,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'elements' => [
                 'arguments',
                 'arrays',
+                'parameters',
             ],
         ],
         'trim_array_spaces' => true,


### PR DESCRIPTION
This pull request

* [x] configures the `trailing_comma_in_multiline` fixer to add trailing commas for parameters

Follows #400.