### PR TITLE
Enhancement: Configure function_to_constant fixer to include get_called_class()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.14.0...main`][2.14.0...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#420]), by [@localheinz]
+* Configured `function_to_constant` to include `get_called_class()` ([#421]), by [@localheinz]
 
 ### Fixed
 
@@ -427,6 +428,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#415]: https://github.com/ergebnis/php-cs-fixer-config/pull/415
 [#416]: https://github.com/ergebnis/php-cs-fixer-config/pull/416
 [#420]: https://github.com/ergebnis/php-cs-fixer-config/pull/420
+[#421]: https://github.com/ergebnis/php-cs-fixer-config/pull/421
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -524,6 +524,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'function_to_constant' => [
             'functions' => [
+                'get_called_class',
                 'get_class',
                 'php_sapi_name',
                 'phpversion',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -524,6 +524,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'function_to_constant' => [
             'functions' => [
+                'get_called_class',
                 'get_class',
                 'php_sapi_name',
                 'phpversion',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -524,6 +524,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'function_to_constant' => [
             'functions' => [
+                'get_called_class',
                 'get_class',
                 'php_sapi_name',
                 'phpversion',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -530,6 +530,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         ],
         'function_to_constant' => [
             'functions' => [
+                'get_called_class',
                 'get_class',
                 'php_sapi_name',
                 'phpversion',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -530,6 +530,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'function_to_constant' => [
             'functions' => [
+                'get_called_class',
                 'get_class',
                 'php_sapi_name',
                 'phpversion',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -530,6 +530,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'function_to_constant' => [
             'functions' => [
+                'get_called_class',
                 'get_class',
                 'php_sapi_name',
                 'phpversion',


### PR DESCRIPTION
This pull request

- [x] configures the `function_to_constant` fixer to include `get_called_class()`

Follows #420.