### PR TITLE
Enhancement: Configure phpdoc_align fixer to include method and property annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.14.0...main`][2.14.0...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#420]), by [@localheinz]
 * Configured `function_to_constant` to include `get_called_class()` ([#421]), by [@localheinz]
+* Configured `phpdoc_align` fixer to include `@method` and `@property` annotations ([#422]), by [@localheinz]
 
 ### Fixed
 
@@ -429,6 +430,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#416]: https://github.com/ergebnis/php-cs-fixer-config/pull/416
 [#420]: https://github.com/ergebnis/php-cs-fixer-config/pull/420
 [#421]: https://github.com/ergebnis/php-cs-fixer-config/pull/421
+[#422]: https://github.com/ergebnis/php-cs-fixer-config/pull/422
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -796,7 +796,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_align' => [
             'align' => 'vertical',
             'tags' => [
+                'method',
                 'param',
+                'property',
                 'return',
                 'throws',
                 'type',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -796,7 +796,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_align' => [
             'align' => 'vertical',
             'tags' => [
+                'method',
                 'param',
+                'property',
                 'return',
                 'throws',
                 'type',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -796,7 +796,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_align' => [
             'align' => 'vertical',
             'tags' => [
+                'method',
                 'param',
+                'property',
                 'return',
                 'throws',
                 'type',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -802,7 +802,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'phpdoc_align' => [
             'align' => 'vertical',
             'tags' => [
+                'method',
                 'param',
+                'property',
                 'return',
                 'throws',
                 'type',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -802,7 +802,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'phpdoc_align' => [
             'align' => 'vertical',
             'tags' => [
+                'method',
                 'param',
+                'property',
                 'return',
                 'throws',
                 'type',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -802,7 +802,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'phpdoc_align' => [
             'align' => 'vertical',
             'tags' => [
+                'method',
                 'param',
+                'property',
                 'return',
                 'throws',
                 'type',


### PR DESCRIPTION
This pull request

* [x] configures the `phpdoc_align` to include `@method` and `@property` annotations

Follows #420.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/doc/rules/phpdoc/phpdoc_align.rst.