### PR TITLE
Fix: Use major.minor.patch version

### DIFF
--- a/.github/workflows/prune.yaml
+++ b/.github/workflows/prune.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Prune issues and pull requests"
-        uses: "actions/stale@v4"
+        uses: "actions/stale@v4.0.0"
         with:
           days-before-close: "${{ env.DAYS_BEFORE_CLOSE }}"
           days-before-stale: "${{ env.DAYS_BEFORE_STALE }}"


### PR DESCRIPTION
This pull request

* [x] uses `major.minor.patch` version when referencing an action