### PR TITLE
Enhancement: Enable declare_parentheses fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#475]), by [@dependabot]
+* Enabled `declare_parentheses` fixer ([#476]), by [@localheinz]
 
 ## [`3.0.2`][3.0.2]
 
@@ -466,6 +467,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#428]: https://github.com/ergebnis/php-cs-fixer-config/pull/428
 [#462]: https://github.com/ergebnis/php-cs-fixer-config/pull/462
 [#475]: https://github.com/ergebnis/php-cs-fixer-config/pull/475
+[#476]: https://github.com/ergebnis/php-cs-fixer-config/pull/476
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -97,7 +97,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'declare_equal_normalize' => [
             'space' => 'none',
         ],
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -97,7 +97,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'declare_equal_normalize' => [
             'space' => 'none',
         ],
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -97,7 +97,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'declare_equal_normalize' => [
             'space' => 'none',
         ],
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -103,7 +103,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'declare_equal_normalize' => [
             'space' => 'none',
         ],
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -103,7 +103,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'declare_equal_normalize' => [
             'space' => 'none',
         ],
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -103,7 +103,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'declare_equal_normalize' => [
             'space' => 'none',
         ],
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [


### PR DESCRIPTION
This pull request

* [x] enables the `declare_parentheses` fixer

Follows https://github.com/ergebnis/php-cs-fixer-config/pull/475.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/doc/rules/language_construct/declare_parentheses.rst.