### PR TITLE
Enhancement: Enable and configure `empty_loop_body` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#475]), by [@dependabot]
 * Enabled `declare_parentheses` fixer ([#476]), by [@localheinz]
+* Enabled and configured `empty_loop_body` fixer ([#477]), by [@localheinz]
 
 ## [`3.0.2`][3.0.2]
 
@@ -468,6 +469,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#462]: https://github.com/ergebnis/php-cs-fixer-config/pull/462
 [#475]: https://github.com/ergebnis/php-cs-fixer-config/pull/475
 [#476]: https://github.com/ergebnis/php-cs-fixer-config/pull/476
+[#477]: https://github.com/ergebnis/php-cs-fixer-config/pull/477
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -485,7 +485,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -485,7 +485,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -485,7 +485,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -491,7 +491,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -491,7 +491,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -491,7 +491,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [


### PR DESCRIPTION
This pull request

* [x] enables and configures the `empty_loop_body` fixer

Follows https://github.com/ergebnis/php-cs-fixer-config/pull/475.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/doc/rules/control_structure/empty_loop_body.rst.