### PR TITLE
Enhancement: Enable and configure `types_spaces` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Updated `friendsofphp/php-cs-fixer` ([#475]), by [@dependabot]
 * Enabled `declare_parentheses` fixer ([#476]), by [@localheinz]
 * Enabled and configured `empty_loop_body` fixer ([#477]), by [@localheinz]
+* Enabled and configured `types_spaces` fixer ([#478]), by [@localheinz]
 
 ## [`3.0.2`][3.0.2]
 
@@ -470,6 +471,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#475]: https://github.com/ergebnis/php-cs-fixer-config/pull/475
 [#476]: https://github.com/ergebnis/php-cs-fixer-config/pull/476
 [#477]: https://github.com/ergebnis/php-cs-fixer-config/pull/477
+[#478]: https://github.com/ergebnis/php-cs-fixer-config/pull/478
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -1036,7 +1036,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'trim_array_spaces' => true,
-        'types_spaces' => false,
+        'types_spaces' => [
+            'space' => 'none',
+        ],
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,
         'visibility_required' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -1038,7 +1038,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'trim_array_spaces' => true,
-        'types_spaces' => false,
+        'types_spaces' => [
+            'space' => 'none',
+        ],
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,
         'visibility_required' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -1039,7 +1039,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'trim_array_spaces' => true,
-        'types_spaces' => false,
+        'types_spaces' => [
+            'space' => 'none',
+        ],
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,
         'visibility_required' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -1042,7 +1042,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
             ],
         ],
         'trim_array_spaces' => true,
-        'types_spaces' => false,
+        'types_spaces' => [
+            'space' => 'none',
+        ],
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,
         'visibility_required' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -1044,7 +1044,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
         ],
         'trim_array_spaces' => true,
-        'types_spaces' => false,
+        'types_spaces' => [
+            'space' => 'none',
+        ],
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,
         'visibility_required' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -1045,7 +1045,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
         ],
         'trim_array_spaces' => true,
-        'types_spaces' => false,
+        'types_spaces' => [
+            'space' => 'none',
+        ],
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,
         'visibility_required' => [


### PR DESCRIPTION
This pull request

* [x] enables and configures the `types_spaces` fixer

Follows https://github.com/ergebnis/php-cs-fixer-config/pull/475.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/doc/rules/whitespace/types_spaces.rst.