### PR TITLE
Enhancement: Configure `class_attributes_separation` fixer to use `only_if_meta` option for elements `const` and `property`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Enabled `declare_parentheses` fixer ([#476]), by [@localheinz]
 * Enabled and configured `empty_loop_body` fixer ([#477]), by [@localheinz]
 * Enabled and configured `types_spaces` fixer ([#478]), by [@localheinz]
+* Configured `class_attributes_separation` fixer to use newly added `only_if_meta` option for elements `const` and `property` ([#479]), by [@localheinz]
 
 ## [`3.0.2`][3.0.2]
 
@@ -472,6 +473,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#476]: https://github.com/ergebnis/php-cs-fixer-config/pull/476
 [#477]: https://github.com/ergebnis/php-cs-fixer-config/pull/477
 [#478]: https://github.com/ergebnis/php-cs-fixer-config/pull/478
+[#479]: https://github.com/ergebnis/php-cs-fixer-config/pull/479
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -16,7 +16,6 @@ namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'ergebnis (PHP 7.3)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -1058,6 +1057,5 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-
     protected $targetPhpVersion = 70300;
 }

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -69,8 +69,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
-                'property' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -16,7 +16,6 @@ namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'ergebnis (PHP 7.4)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -1060,6 +1059,5 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-
     protected $targetPhpVersion = 70400;
 }

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -69,8 +69,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
-                'property' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -16,7 +16,6 @@ namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'ergebnis (PHP 8.0)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -1061,6 +1060,5 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-
     protected $targetPhpVersion = 80000;
 }

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -69,8 +69,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
-                'property' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -75,8 +75,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
-                'property' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -22,7 +22,6 @@ namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php73Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'ergebnis (PHP 7.3)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -1064,6 +1063,5 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-
     protected $targetPhpVersion = 70300;
 }

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -22,7 +22,6 @@ namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php74Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'ergebnis (PHP 7.4)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -1066,6 +1065,5 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-
     protected $targetPhpVersion = 70400;
 }

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -75,8 +75,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
-                'property' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -75,8 +75,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
-                'property' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -22,7 +22,6 @@ namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php80Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'ergebnis (PHP 8.0)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -1067,6 +1066,5 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-
     protected $targetPhpVersion = 80000;
 }


### PR DESCRIPTION
This pull request

* [x] configures the `class_attributes_separation` fixer to use the newly added `only_if_meta` option for elements `const` and `property`
* [x] runs `make coding-standards`

Follows https://github.com/ergebnis/php-cs-fixer-config/pull/475.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/doc/rules/whitespace/types_spaces.rst.