### PR TITLE
Enhancement: Configure `class_attributes_separation` fixer to use `none` option for element `trait_import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Enabled and configured `empty_loop_body` fixer ([#477]), by [@localheinz]
 * Enabled and configured `types_spaces` fixer ([#478]), by [@localheinz]
 * Configured `class_attributes_separation` fixer to use newly added `only_if_meta` option for elements `const` and `property` ([#479]), by [@localheinz]
+* Configured `class_attributes_separation` fixer to use `none` option for element `trait_import` ([#480]), by [@localheinz]
 
 ## [`3.0.2`][3.0.2]
 
@@ -474,6 +475,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#477]: https://github.com/ergebnis/php-cs-fixer-config/pull/477
 [#478]: https://github.com/ergebnis/php-cs-fixer-config/pull/478
 [#479]: https://github.com/ergebnis/php-cs-fixer-config/pull/479
+[#480]: https://github.com/ergebnis/php-cs-fixer-config/pull/490
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -71,6 +71,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -71,6 +71,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -71,6 +71,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -77,6 +77,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -77,6 +77,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -77,6 +77,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [


### PR DESCRIPTION
This pull request

* [x] configures the `class_attributes_separation` fixer to use the `none` option for element `trait_import`

Follows #461.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.1/doc/rules/class_notation/class_attributes_separation.rst.