### PR TITLE
Fix: Stop using deprecated `use_trait` option for `no_extra_blank_lines` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#495]), by [@dependabot]
 
+### Fixed
+
+* Stopped using deprecated `use_trait` option for `no_extra_blank_lines` fixer ([#496]), by [@dependabot]
+
 ## [`3.1.0`][3.1.0]
 
 For a full diff see [`3.0.2...3.1.0`][3.0.2...3.1.0].
@@ -491,6 +495,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#481]: https://github.com/ergebnis/php-cs-fixer-config/pull/481
 [#483]: https://github.com/ergebnis/php-cs-fixer-config/pull/483
 [#495]: https://github.com/ergebnis/php-cs-fixer-config/pull/495
+[#496]: https://github.com/ergebnis/php-cs-fixer-config/pull/496
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -287,7 +287,6 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -287,7 +287,6 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -287,7 +287,6 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -293,7 +293,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -293,7 +293,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -293,7 +293,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,


### PR DESCRIPTION
This pull request

* [x] stop using the deprecated `use_trait` option for the `no_extra_blank_lines` fixer

Follows #495.