### PR TITLE
Enhancement: Enable and configure `control_structure_continuation_position` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#495]), by [@dependabot]
 * Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#497]), by [@localheinz]
+* Enabled and configured `control_structure_continuation_position` fixer ([#498]), by [@localheinz]
 
 ### Fixed
 
@@ -498,6 +499,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#495]: https://github.com/ergebnis/php-cs-fixer-config/pull/495
 [#496]: https://github.com/ergebnis/php-cs-fixer-config/pull/496
 [#497]: https://github.com/ergebnis/php-cs-fixer-config/pull/497
+[#498]: https://github.com/ergebnis/php-cs-fixer-config/pull/498
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -95,7 +95,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -95,7 +95,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -95,7 +95,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -101,7 +101,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -101,7 +101,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -101,7 +101,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',


### PR DESCRIPTION
This pull request

* [x] enables and configures the `control_structure_continuation_position` fixer

Follows #495.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/control_structure/control_structure_continuation_position.rst.
