### PR TITLE
Enhancement: Enable and configure `empty_loop_condition` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Updated `friendsofphp/php-cs-fixer` ([#495]), by [@dependabot]
 * Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#497]), by [@localheinz]
 * Enabled and configured `control_structure_continuation_position` fixer ([#498]), by [@localheinz]
+* Enabled and configured `empty_loop_condition` fixer ([#499]), by [@localheinz]
 
 ### Fixed
 
@@ -500,6 +501,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#496]: https://github.com/ergebnis/php-cs-fixer-config/pull/496
 [#497]: https://github.com/ergebnis/php-cs-fixer-config/pull/497
 [#498]: https://github.com/ergebnis/php-cs-fixer-config/pull/498
+[#499]: https://github.com/ergebnis/php-cs-fixer-config/pull/499
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -137,7 +137,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -137,7 +137,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -137,7 +137,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -143,7 +143,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -143,7 +143,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -143,7 +143,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => [


### PR DESCRIPTION
This pull request

* [x] enables and configures the `empty_loop_condition` fixer

Follows #495.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/control_structure/empty_loop_condition.rst.