### PR TITLE
Enhancement: Enable `integer_literal_case` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#497]), by [@localheinz]
 * Enabled and configured `control_structure_continuation_position` fixer ([#498]), by [@localheinz]
 * Enabled and configured `empty_loop_condition` fixer ([#499]), by [@localheinz]
+* Enabled `integer_literal_case` fixer ([#500]), by [@localheinz]
 
 ### Fixed
 
@@ -502,6 +503,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#497]: https://github.com/ergebnis/php-cs-fixer-config/pull/497
 [#498]: https://github.com/ergebnis/php-cs-fixer-config/pull/498
 [#499]: https://github.com/ergebnis/php-cs-fixer-config/pull/499
+[#500]: https://github.com/ergebnis/php-cs-fixer-config/pull/500
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -209,7 +209,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -209,7 +209,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -209,7 +209,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -215,7 +215,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -215,7 +215,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -215,7 +215,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,


### PR DESCRIPTION
This pull request

* [x] enables and configures the `integer_literal_case` fixer

Follows #495.

💁‍♂️ For reference, https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/casing/integer_literal_case.rst.