### PR TITLE
Enhancement: Enable `modernize_strpos` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Enabled and configured `control_structure_continuation_position` fixer ([#498]), by [@localheinz]
 * Enabled and configured `empty_loop_condition` fixer ([#499]), by [@localheinz]
 * Enabled `integer_literal_case` fixer ([#500]), by [@localheinz]
+* Enabled `modernize_strpos` fixer for `Php80` rule set ([#501]), by [@localheinz]
 
 ### Fixed
 
@@ -504,6 +505,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#498]: https://github.com/ergebnis/php-cs-fixer-config/pull/498
 [#499]: https://github.com/ergebnis/php-cs-fixer-config/pull/499
 [#500]: https://github.com/ergebnis/php-cs-fixer-config/pull/500
+[#501]: https://github.com/ergebnis/php-cs-fixer-config/pull/501
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -230,7 +230,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_strpos' => false,
+        'modernize_strpos' => true,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -236,7 +236,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_strpos' => false,
+        'modernize_strpos' => true,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [


### PR DESCRIPTION
This pull request

* [x] enables and configures the `modernize_strpos` fixer

Follows #495.

💁‍♂️ For reference, https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/alias/modernize_strpos.rst.