### PR TITLE
Enhancement: Enable `no_space_around_double_colon` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Enabled and configured `empty_loop_condition` fixer ([#499]), by [@localheinz]
 * Enabled `integer_literal_case` fixer ([#500]), by [@localheinz]
 * Enabled `modernize_strpos` fixer for `Php80` rule set ([#501]), by [@localheinz]
+* Enabled `no_space_around_double_colon` fixer ([#502]), by [@localheinz]
 
 ### Fixed
 
@@ -506,6 +507,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#499]: https://github.com/ergebnis/php-cs-fixer-config/pull/499
 [#500]: https://github.com/ergebnis/php-cs-fixer-config/pull/500
 [#501]: https://github.com/ergebnis/php-cs-fixer-config/pull/501
+[#502]: https://github.com/ergebnis/php-cs-fixer-config/pull/502
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -304,7 +304,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => [
             'positions' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -304,7 +304,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => [
             'positions' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -304,7 +304,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => [
             'positions' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -310,7 +310,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => [
             'positions' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -310,7 +310,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => [
             'positions' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -310,7 +310,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => [
             'positions' => [


### PR DESCRIPTION
This pull request

* [x] enables and configures the `no_space_around_double_colon` fixer

Follows #495.

💁‍♂️ For reference, https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/operator/no_space_around_double_colon.rst.