### PR TITLE
Enhancement: Enable `string_length_to_empty` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`3.0.2...main`][3.0.2...main].
+For a full diff see [`3.2.0...main`][3.2.0...main].
+
+## [`3.2.0`][3.2.0]
+
+For a full diff see [`3.1.0...3.2.0`][3.1.0...3.2.0].
 
 ### Changed
 
@@ -17,6 +21,7 @@ For a full diff see [`3.0.2...main`][3.0.2...main].
 * Enabled `integer_literal_case` fixer ([#500]), by [@localheinz]
 * Enabled `modernize_strpos` fixer for `Php80` rule set ([#501]), by [@localheinz]
 * Enabled `no_space_around_double_colon` fixer ([#502]), by [@localheinz]
+* Enabled `string_length_to_empty` fixer ([#503]), by [@localheinz]
 
 ### Fixed
 
@@ -379,6 +384,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [3.0.1]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/3.0.1
 [3.0.2]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/3.0.2
 [3.1.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/3.1.0
+[3.2.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/3.2.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -412,7 +418,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [3.0.0...3.0.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.0.0...3.0.1
 [3.0.1...3.0.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.0.1...3.0.2
 [3.0.2...3.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.0.2...3.1.0
-[3.1.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.1.0...main
+[3.1.0...3.2.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.1.0...3.2.0
+[3.2.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.2.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -508,6 +515,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#500]: https://github.com/ergebnis/php-cs-fixer-config/pull/500
 [#501]: https://github.com/ergebnis/php-cs-fixer-config/pull/501
 [#502]: https://github.com/ergebnis/php-cs-fixer-config/pull/502
+[#503]: https://github.com/ergebnis/php-cs-fixer-config/pull/503
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -680,7 +680,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -682,7 +682,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -682,7 +682,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -686,7 +686,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -688,7 +688,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -688,7 +688,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,


### PR DESCRIPTION
This pull request

* [x] enables the `string_length_to_empty` fixer

Follows #495.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/string_notation/string_length_to_empty.rst.