### PR TITLE
Enhancement: Enable `get_class_to_class_keyword` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`3.4.0...main`][3.4.0...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#545]), by [@dependabot]
+* Enabled `get_class_to_class_keyword` fixer, ([#553]), by [@localheinz]
 
 ### Fixed
 
@@ -560,6 +561,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#540]: https://github.com/ergebnis/php-cs-fixer-config/pull/540
 [#544]: https://github.com/ergebnis/php-cs-fixer-config/pull/544
 [#545]: https://github.com/ergebnis/php-cs-fixer-config/pull/545
+[#553]: https://github.com/ergebnis/php-cs-fixer-config/pull/553
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -198,7 +198,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -198,7 +198,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -204,7 +204,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -204,7 +204,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,


### PR DESCRIPTION
This pull request

- [x] enables the `get_class_to_class_keyword` fixer

Follows #545.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.5.0/doc/rules/language_construct/get_class_to_class_keyword.rst.