### PR TITLE
Enhancement: Enable `class_reference_name_casing` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.0.0...main`][4.0.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#565]), by [@dependabot]
+- Enabled `class_reference_name_casing` fixer, ([#566]), by [@localheinz]
 
 ## [`4.0.0`][4.0.0]
 
@@ -573,6 +574,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#545]: https://github.com/ergebnis/php-cs-fixer-config/pull/545
 [#553]: https://github.com/ergebnis/php-cs-fixer-config/pull/553
 [#565]: https://github.com/ergebnis/php-cs-fixer-config/pull/565
+[#566]: https://github.com/ergebnis/php-cs-fixer-config/pull/566
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -81,7 +81,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'single_line' => false,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -81,7 +81,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'single_line' => false,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -81,7 +81,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'single_line' => false,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -87,7 +87,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'single_line' => false,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -87,7 +87,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'single_line' => false,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -87,7 +87,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'single_line' => false,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `class_reference_name_casing` fixer

Follows #565.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.6.0/doc/rules/casing/class_reference_name_casing.rst.