### PR TITLE
Enhancement: Enable `no_unneeded_import_alias` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`4.0.0...main`][4.0.0...main].
+For a full diff see [`4.1.0...main`][4.1.0...main].
+
+## [`4.1.0`][4.1.0]
+
+For a full diff see [`4.0.0...4.1.0`][4.0.0...4.1.0].
 
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#565]), by [@dependabot]
 - Enabled `class_reference_name_casing` fixer, ([#566]), by [@localheinz]
+- Enabled `no_unneeded_import_alias` fixer, ([#567]), by [@localheinz]
 
 ## [`4.0.0`][4.0.0]
 
@@ -431,6 +436,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [3.3.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/3.3.0
 [3.4.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/3.4.0
 [4.0.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.0.0
+[4.1.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.1.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -468,7 +474,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [3.2.0...3.3.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.2.0...3.3.0
 [3.3.0...3.4.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.3.0...3.4.0
 [3.4.0...3.4.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/3.4.0...4.0.0
-[4.0.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.0.0...main
+[4.0.0...4.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.0.0...4.1.0
+[4.1.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.1.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -575,6 +582,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#553]: https://github.com/ergebnis/php-cs-fixer-config/pull/553
 [#565]: https://github.com/ergebnis/php-cs-fixer-config/pull/565
 [#566]: https://github.com/ergebnis/php-cs-fixer-config/pull/566
+[#567]: https://github.com/ergebnis/php-cs-fixer-config/pull/567
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -343,7 +343,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unneeded_final_method' => [
             'private_methods' => true,
         ],
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -343,7 +343,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unneeded_final_method' => [
             'private_methods' => true,
         ],
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -343,7 +343,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unneeded_final_method' => [
             'private_methods' => true,
         ],
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -349,7 +349,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'no_unneeded_final_method' => [
             'private_methods' => true,
         ],
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -349,7 +349,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'no_unneeded_final_method' => [
             'private_methods' => true,
         ],
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -349,7 +349,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'no_unneeded_final_method' => [
             'private_methods' => true,
         ],
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_unneeded_import_alias` fixer

Follows #565.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.6.0/doc/rules/import/no_unneeded_import_alias.rst.