### PR TITLE
Enhancement: Enable `no_trailing_comma_in_singleline_function_call` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.1.0...main`][4.1.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#578]), by [@dependabot]
+- Enabled `no_trailing_comma_in_singleline_function_call` fixer ([#579]), by [@localheinz]
 
 ## [`4.1.0`][4.1.0]
 
@@ -588,6 +589,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#566]: https://github.com/ergebnis/php-cs-fixer-config/pull/566
 [#567]: https://github.com/ergebnis/php-cs-fixer-config/pull/567
 [#578]: https://github.com/ergebnis/php-cs-fixer-config/pull/578
+[#579]: https://github.com/ergebnis/php-cs-fixer-config/pull/579
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -325,7 +325,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
-        'no_trailing_comma_in_singleline_function_call' => false,
+        'no_trailing_comma_in_singleline_function_call' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -325,7 +325,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
-        'no_trailing_comma_in_singleline_function_call' => false,
+        'no_trailing_comma_in_singleline_function_call' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -325,7 +325,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
-        'no_trailing_comma_in_singleline_function_call' => false,
+        'no_trailing_comma_in_singleline_function_call' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -331,7 +331,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
-        'no_trailing_comma_in_singleline_function_call' => false,
+        'no_trailing_comma_in_singleline_function_call' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -331,7 +331,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
-        'no_trailing_comma_in_singleline_function_call' => false,
+        'no_trailing_comma_in_singleline_function_call' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -331,7 +331,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ],
         'no_trailing_comma_in_list_call' => true,
         'no_trailing_comma_in_singleline_array' => true,
-        'no_trailing_comma_in_singleline_function_call' => false,
+        'no_trailing_comma_in_singleline_function_call' => true,
         'no_trailing_whitespace' => true,
         'no_trailing_whitespace_in_comment' => true,
         'no_trailing_whitespace_in_string' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_trailing_comma_in_singleline_function_call` fixer

Follows #578.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc/rules/function_notation/no_trailing_comma_in_singleline_function_call.rst.