### PR TITLE
Enhancement: Enable `single_line_comment_spacing` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`4.1.0...main`][4.1.0...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#578]), by [@dependabot]
 - Enabled `no_trailing_comma_in_singleline_function_call` fixer ([#579]), by [@localheinz]
+- Enabled `single_line_comment_spacing` fixer ([#580]), by [@localheinz]
 
 ## [`4.1.0`][4.1.0]
 
@@ -590,6 +591,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#567]: https://github.com/ergebnis/php-cs-fixer-config/pull/567
 [#578]: https://github.com/ergebnis/php-cs-fixer-config/pull/578
 [#579]: https://github.com/ergebnis/php-cs-fixer-config/pull/579
+[#580]: https://github.com/ergebnis/php-cs-fixer-config/pull/580
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -609,7 +609,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
-        'single_line_comment_spacing' => false,
+        'single_line_comment_spacing' => true,
         'single_line_comment_style' => [
             'comment_types' => [
                 'hash',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -609,7 +609,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
-        'single_line_comment_spacing' => false,
+        'single_line_comment_spacing' => true,
         'single_line_comment_style' => [
             'comment_types' => [
                 'hash',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -609,7 +609,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
-        'single_line_comment_spacing' => false,
+        'single_line_comment_spacing' => true,
         'single_line_comment_style' => [
             'comment_types' => [
                 'hash',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -615,7 +615,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
-        'single_line_comment_spacing' => false,
+        'single_line_comment_spacing' => true,
         'single_line_comment_style' => [
             'comment_types' => [
                 'hash',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -615,7 +615,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
-        'single_line_comment_spacing' => false,
+        'single_line_comment_spacing' => true,
         'single_line_comment_style' => [
             'comment_types' => [
                 'hash',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -615,7 +615,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ],
         'single_import_per_statement' => true,
         'single_line_after_imports' => true,
-        'single_line_comment_spacing' => false,
+        'single_line_comment_spacing' => true,
         'single_line_comment_style' => [
             'comment_types' => [
                 'hash',


### PR DESCRIPTION
This pull request

- [x] enables the `single_line_comment_spacing` fixer

Follows #578.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc%2Frules%2Fcomment%2Fsingle_line_comment_spacing.rst.