### PR TITLE
Enhancement: Configure `blank_line_before_statement` fixer to include additional statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`4.2.0...main`][4.2.0...main].
 
+### Changed
+
+- Configured `blank_line_before_statement` fixer to include additional statements ([#581]), by [@localheinz]
+
 ## [`4.2.0`][4.2.0]
 
 For a full diff see [`4.1.0...4.2.0`][4.1.0...4.2.0].
@@ -598,6 +602,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#578]: https://github.com/ergebnis/php-cs-fixer-config/pull/578
 [#579]: https://github.com/ergebnis/php-cs-fixer-config/pull/579
 [#580]: https://github.com/ergebnis/php-cs-fixer-config/pull/580
+[#581]: https://github.com/ergebnis/php-cs-fixer-config/pull/581
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -36,6 +36,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -47,6 +48,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -55,6 +57,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -36,6 +36,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -47,6 +48,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -55,6 +57,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -36,6 +36,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -47,6 +48,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -55,6 +57,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -42,6 +42,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -53,6 +54,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -61,6 +63,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -42,6 +42,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -53,6 +54,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -61,6 +63,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -42,6 +42,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'blank_line_before_statement' => [
             'statements' => [
                 'break',
+                'case',
                 'continue',
                 'declare',
                 'default',
@@ -53,6 +54,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'if',
                 'include',
                 'include_once',
+                'phpdoc',
                 'require',
                 'require_once',
                 'return',
@@ -61,6 +63,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'try',
                 'while',
                 'yield',
+                'yield_from',
             ],
         ],
         'braces' => [


### PR DESCRIPTION
This pull request

- [x] configures the `blank_line_before_statement` fixer to include additional statements

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc/rules/whitespace/blank_line_before_statement.rst.