### PR TITLE
Enhancement: Configure `no_unneeded_control_parentheses` fixer to include additional statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.2.0...main`][4.2.0...main].
 ### Changed
 
 - Configured `blank_line_before_statement` fixer to include additional statements ([#581]), by [@localheinz]
+- Configured `no_unneeded_control_parentheses` fixer to include additional statements ([#583]), by [@localheinz]
 
 ## [`4.2.0`][4.2.0]
 
@@ -603,6 +604,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#579]: https://github.com/ergebnis/php-cs-fixer-config/pull/579
 [#580]: https://github.com/ergebnis/php-cs-fixer-config/pull/580
 [#581]: https://github.com/ergebnis/php-cs-fixer-config/pull/581
+[#583]: https://github.com/ergebnis/php-cs-fixer-config/pull/583
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -341,6 +341,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'return',
                 'switch_case',
                 'yield',
+                'yield_from',
             ],
         ],
         'no_unneeded_curly_braces' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -341,6 +341,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'return',
                 'switch_case',
                 'yield',
+                'yield_from',
             ],
         ],
         'no_unneeded_curly_braces' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -341,6 +341,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'return',
                 'switch_case',
                 'yield',
+                'yield_from',
             ],
         ],
         'no_unneeded_curly_braces' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -347,6 +347,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'return',
                 'switch_case',
                 'yield',
+                'yield_from',
             ],
         ],
         'no_unneeded_curly_braces' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -347,6 +347,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'return',
                 'switch_case',
                 'yield',
+                'yield_from',
             ],
         ],
         'no_unneeded_curly_braces' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -347,6 +347,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'return',
                 'switch_case',
                 'yield',
+                'yield_from',
             ],
         ],
         'no_unneeded_curly_braces' => [


### PR DESCRIPTION
This pull request

- [x] configures the `no_unneeded_control_parentheses` fixer to include additional statements

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc/rules/control_structure/no_unneeded_control_parentheses.rst.