### PR TITLE
Enhancement: Configure `ordered_class_elements` fixer to order more elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`4.2.0...main`][4.2.0...main].
 
 - Configured `blank_line_before_statement` fixer to include additional statements ([#581]), by [@localheinz]
 - Configured `no_unneeded_control_parentheses` fixer to include additional statements ([#583]), by [@localheinz]
+- Configured `ordered_class_elements` fixer to order more elements ([#584]), by [@localheinz]
 
 ## [`4.2.0`][4.2.0]
 
@@ -605,6 +606,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#580]: https://github.com/ergebnis/php-cs-fixer-config/pull/580
 [#581]: https://github.com/ergebnis/php-cs-fixer-config/pull/581
 [#583]: https://github.com/ergebnis/php-cs-fixer-config/pull/583
+[#584]: https://github.com/ergebnis/php-cs-fixer-config/pull/584
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -380,6 +380,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'ordered_class_elements' => [
             'order' => [
                 'use_trait',
+                'case',
                 'constant_public',
                 'constant_protected',
                 'constant_private',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -386,6 +386,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'ordered_class_elements' => [
             'order' => [
                 'use_trait',
+                'case',
                 'constant_public',
                 'constant_protected',
                 'constant_private',


### PR DESCRIPTION
This pull request

- [x] configures the `ordered_class_elements` fixer to order more elements

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc%2Frules%2Fclass_notation%2Fordered_class_elements.rst.