### PR TITLE
Enhancement: Configure `phpdoc_align` fixer to align more tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`4.2.0...main`][4.2.0...main].
 - Configured `blank_line_before_statement` fixer to include additional statements ([#581]), by [@localheinz]
 - Configured `no_unneeded_control_parentheses` fixer to include additional statements ([#583]), by [@localheinz]
 - Configured `ordered_class_elements` fixer to order more elements ([#584]), by [@localheinz]
+- Configured `phpdoc_aling` fixer to align more tags ([#586]), by [@localheinz]
 
 ## [`4.2.0`][4.2.0]
 
@@ -607,6 +608,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#581]: https://github.com/ergebnis/php-cs-fixer-config/pull/581
 [#583]: https://github.com/ergebnis/php-cs-fixer-config/pull/583
 [#584]: https://github.com/ergebnis/php-cs-fixer-config/pull/584
+[#586]: https://github.com/ergebnis/php-cs-fixer-config/pull/586
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -468,6 +468,8 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'method',
                 'param',
                 'property',
+                'property-read',
+                'property-write',
                 'return',
                 'throws',
                 'type',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -468,6 +468,8 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'method',
                 'param',
                 'property',
+                'property-read',
+                'property-write',
                 'return',
                 'throws',
                 'type',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -469,6 +469,8 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'method',
                 'param',
                 'property',
+                'property-read',
+                'property-write',
                 'return',
                 'throws',
                 'type',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -474,6 +474,8 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'method',
                 'param',
                 'property',
+                'property-read',
+                'property-write',
                 'return',
                 'throws',
                 'type',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -474,6 +474,8 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'method',
                 'param',
                 'property',
+                'property-read',
+                'property-write',
                 'return',
                 'throws',
                 'type',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -475,6 +475,8 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'method',
                 'param',
                 'property',
+                'property-read',
+                'property-write',
                 'return',
                 'throws',
                 'type',


### PR DESCRIPTION
This pull request

- [x] configures the `phpdoc_align` fixer to align more tags

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc/rules/phpdoc/phpdoc_align.rst.