### PR TITLE
Enhancement: Configure `single_class_element_per_statement` fixer to enforce single class element for `const` statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`4.2.0...main`][4.2.0...main].
 - Configured `no_unneeded_control_parentheses` fixer to include additional statements ([#583]), by [@localheinz]
 - Configured `ordered_class_elements` fixer to order more elements ([#584]), by [@localheinz]
 - Configured `phpdoc_align` fixer to align more tags ([#586]), by [@localheinz]
+- Configured `single_class_element_per_statement` fixer to enforce single class element for `const` statements ([#587]), by [@localheinz]
 
 ## [`4.2.0`][4.2.0]
 
@@ -609,6 +610,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#583]: https://github.com/ergebnis/php-cs-fixer-config/pull/583
 [#584]: https://github.com/ergebnis/php-cs-fixer-config/pull/584
 [#586]: https://github.com/ergebnis/php-cs-fixer-config/pull/586
+[#587]: https://github.com/ergebnis/php-cs-fixer-config/pull/587
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -610,6 +610,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => [
             'elements' => [
+                'const',
                 'property',
             ],
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -610,6 +610,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => [
             'elements' => [
+                'const',
                 'property',
             ],
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -611,6 +611,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => [
             'elements' => [
+                'const',
                 'property',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -616,6 +616,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => [
             'elements' => [
+                'const',
                 'property',
             ],
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -616,6 +616,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => [
             'elements' => [
+                'const',
                 'property',
             ],
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -617,6 +617,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'single_blank_line_before_namespace' => true,
         'single_class_element_per_statement' => [
             'elements' => [
+                'const',
                 'property',
             ],
         ],


### PR DESCRIPTION
This pull request

- [x] configures the `single_class_element_per_statement` fixer to enforce single class element for `const` statements

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.7.0/doc%2Frules%2Fclass_notation%2Fsingle_class_element_per_statement.rst.