### PR TITLE
Enhancement: Enable `date_time_create_from_format_call` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For a full diff see [`4.3.0...main`][4.3.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#591]), by [@dependabot]
+- Enabled `date_time_create_from_format_call` fixer ([#592]), by [@localheinz]
+
 
 ## [`4.3.0`][4.3.0]
 
@@ -624,6 +626,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#587]: https://github.com/ergebnis/php-cs-fixer-config/pull/587
 [#588]: https://github.com/ergebnis/php-cs-fixer-config/pull/588
 [#591]: https://github.com/ergebnis/php-cs-fixer-config/pull/591
+[#592]: https://github.com/ergebnis/php-cs-fixer-config/pull/592
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -103,7 +103,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'date_time_create_from_format_call' => false,
+        'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -103,7 +103,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'date_time_create_from_format_call' => false,
+        'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -103,7 +103,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'date_time_create_from_format_call' => false,
+        'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -109,7 +109,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'date_time_create_from_format_call' => false,
+        'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -109,7 +109,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'date_time_create_from_format_call' => false,
+        'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -109,7 +109,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'date_time_create_from_format_call' => false,
+        'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [
             'space' => 'none',


### PR DESCRIPTION
This pull request

- [x] enables the `date_time_create_from_format_call` fixer 

Follows #591.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.8.0/doc/rules/function_notation/date_time_create_from_format_call.rst.