### PR TITLE
Enhancement: Enable `control_structure_braces` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#620]), by [@dependabot]
+- Enabled `control_structure_braces` fixer ([#621]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -639,6 +640,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#592]: https://github.com/ergebnis/php-cs-fixer-config/pull/592
 [#593]: https://github.com/ergebnis/php-cs-fixer-config/pull/593
 [#620]: https://github.com/ergebnis/php-cs-fixer-config/pull/620
+[#621]: https://github.com/ergebnis/php-cs-fixer-config/pull/621
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -101,7 +101,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_braces' => false,
+        'control_structure_braces' => true,
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -101,7 +101,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_braces' => false,
+        'control_structure_braces' => true,
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -101,7 +101,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_braces' => false,
+        'control_structure_braces' => true,
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -107,7 +107,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_braces' => false,
+        'control_structure_braces' => true,
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -107,7 +107,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_braces' => false,
+        'control_structure_braces' => true,
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -107,7 +107,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'constant_case' => [
             'case' => 'lower',
         ],
-        'control_structure_braces' => false,
+        'control_structure_braces' => true,
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],


### PR DESCRIPTION
This pull request

- [x] enables the `control_structure_braces` fixer

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/control_structure/control_structure_braces.rst.