### PR TITLE
Enhancement: Enable and configure `curly_braces_position` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#620]), by [@dependabot]
 - Enabled `control_structure_braces` fixer ([#621]), by [@localheinz]
+- Enabled and configured `curly_braces_position` fixer ([#622]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -641,6 +642,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#593]: https://github.com/ergebnis/php-cs-fixer-config/pull/593
 [#620]: https://github.com/ergebnis/php-cs-fixer-config/pull/620
 [#621]: https://github.com/ergebnis/php-cs-fixer-config/pull/621
+[#622]: https://github.com/ergebnis/php-cs-fixer-config/pull/622
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -105,7 +105,15 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'curly_braces_position' => false,
+        'curly_braces_position' => [
+            'allow_single_line_anonymous_functions' => false,
+            'allow_single_line_empty_anonymous_classes' => false,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
         'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -105,7 +105,15 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'curly_braces_position' => false,
+        'curly_braces_position' => [
+            'allow_single_line_anonymous_functions' => false,
+            'allow_single_line_empty_anonymous_classes' => false,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
         'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -105,7 +105,15 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'curly_braces_position' => false,
+        'curly_braces_position' => [
+            'allow_single_line_anonymous_functions' => false,
+            'allow_single_line_empty_anonymous_classes' => false,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
         'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -111,7 +111,15 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'curly_braces_position' => false,
+        'curly_braces_position' => [
+            'allow_single_line_anonymous_functions' => false,
+            'allow_single_line_empty_anonymous_classes' => false,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
         'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -111,7 +111,15 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'curly_braces_position' => false,
+        'curly_braces_position' => [
+            'allow_single_line_anonymous_functions' => false,
+            'allow_single_line_empty_anonymous_classes' => false,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
         'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -111,7 +111,15 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'control_structure_continuation_position' => [
             'position' => 'same_line',
         ],
-        'curly_braces_position' => false,
+        'curly_braces_position' => [
+            'allow_single_line_anonymous_functions' => false,
+            'allow_single_line_empty_anonymous_classes' => false,
+            'anonymous_classes_opening_brace' => 'same_line',
+            'anonymous_functions_opening_brace' => 'same_line',
+            'classes_opening_brace' => 'next_line_unless_newline_at_signature_end',
+            'control_structures_opening_brace' => 'same_line',
+            'functions_opening_brace' => 'next_line_unless_newline_at_signature_end',
+        ],
         'date_time_create_from_format_call' => true,
         'date_time_immutable' => true,
         'declare_equal_normalize' => [


### PR DESCRIPTION
This pull request

- [x] enables and configures the `curly_braces_position` fixer

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/basic/curly_braces_position.rst.