### PR TITLE
Enhancement: Enable `no_useless_nullsafe_operator` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 - Updated `friendsofphp/php-cs-fixer` ([#620]), by [@dependabot]
 - Enabled `control_structure_braces` fixer ([#621]), by [@localheinz]
 - Enabled and configured `curly_braces_position` fixer ([#622]), by [@localheinz]
+- Enabled `no_useless_nullsafe_operator` fixer ([#623]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -643,6 +644,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#620]: https://github.com/ergebnis/php-cs-fixer-config/pull/620
 [#621]: https://github.com/ergebnis/php-cs-fixer-config/pull/621
 [#622]: https://github.com/ergebnis/php-cs-fixer-config/pull/622
+[#623]: https://github.com/ergebnis/php-cs-fixer-config/pull/623
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -368,7 +368,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_nullsafe_operator' => false,
+        'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -368,7 +368,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_nullsafe_operator' => false,
+        'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -374,7 +374,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_nullsafe_operator' => false,
+        'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -374,7 +374,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,
-        'no_useless_nullsafe_operator' => false,
+        'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
         'no_whitespace_before_comma_in_array' => [


### PR DESCRIPTION
This pull request

- [x] enables the `no_useless_nullsafe_operator` fixer

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/operator/no_useless_nullsafe_operator.rst.