### PR TITLE
Enhancement: Enable `statement_indentation` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 - Enabled `control_structure_braces` fixer ([#621]), by [@localheinz]
 - Enabled and configured `curly_braces_position` fixer ([#622]), by [@localheinz]
 - Enabled `no_useless_nullsafe_operator` fixer ([#623]), by [@localheinz]
+- Enabled `statement_indentation` fixer ([#624]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -645,6 +646,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#621]: https://github.com/ergebnis/php-cs-fixer-config/pull/621
 [#622]: https://github.com/ergebnis/php-cs-fixer-config/pull/622
 [#623]: https://github.com/ergebnis/php-cs-fixer-config/pull/623
+[#624]: https://github.com/ergebnis/php-cs-fixer-config/pull/624
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -707,7 +707,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'statement_indentation' => false,
+        'statement_indentation' => true,
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -707,7 +707,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'statement_indentation' => false,
+        'statement_indentation' => true,
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -710,7 +710,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'statement_indentation' => false,
+        'statement_indentation' => true,
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -713,7 +713,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'statement_indentation' => false,
+        'statement_indentation' => true,
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -713,7 +713,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'statement_indentation' => false,
+        'statement_indentation' => true,
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -716,7 +716,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ],
         'standardize_increment' => true,
         'standardize_not_equals' => true,
-        'statement_indentation' => false,
+        'statement_indentation' => true,
         'static_lambda' => true,
         'strict_comparison' => true,
         'strict_param' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `statement_indentation` fixer

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/whitespace/statement_indentation.rst.