### PR TITLE
Enhancement: Configure `trailing_comma_in_multiline` fixer to include `match` in `elements` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 - Enabled `no_useless_nullsafe_operator` fixer ([#623]), by [@localheinz]
 - Enabled `statement_indentation` fixer ([#624]), by [@localheinz]
 - Configured `no_unneeded_control_parentheses` fixer to include `negative_instanceof` and `others` in the `statements` option ([#625]), by [@localheinz]
+- Configured `trailing_comma_in_multiline` fixer to include `match` in the `elements` option ([#626]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -649,6 +650,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#623]: https://github.com/ergebnis/php-cs-fixer-config/pull/623
 [#624]: https://github.com/ergebnis/php-cs-fixer-config/pull/624
 [#625]: https://github.com/ergebnis/php-cs-fixer-config/pull/625
+[#626]: https://github.com/ergebnis/php-cs-fixer-config/pull/626
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -726,6 +726,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'elements' => [
                 'arguments',
                 'arrays',
+                'match',
                 'parameters',
             ],
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -729,6 +729,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'elements' => [
                 'arguments',
                 'arrays',
+                'match',
                 'parameters',
             ],
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -732,6 +732,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'elements' => [
                 'arguments',
                 'arrays',
+                'match',
                 'parameters',
             ],
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -735,6 +735,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'elements' => [
                 'arguments',
                 'arrays',
+                'match',
                 'parameters',
             ],
         ],


### PR DESCRIPTION
This pull request

- [x] configures the `trailing_comma_in_multiline` fixer to include `match` in the `elements` option

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/control_structure/trailing_comma_in_multiline.rst.