### PR TITLE
Enhancement: Configure `single_space_after_construct` fixer to include `type_colon` in `constructs` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 - Enabled `statement_indentation` fixer ([#624]), by [@localheinz]
 - Configured `no_unneeded_control_parentheses` fixer to include `negative_instanceof` and `others` in the `statements` option ([#625]), by [@localheinz]
 - Configured `trailing_comma_in_multiline` fixer to include `match` in the `elements` option ([#626]), by [@localheinz]
+- Configured `single_space_after_construct` fixer to include `type_colon` in the `constructs` option ([#627]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -651,6 +652,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#624]: https://github.com/ergebnis/php-cs-fixer-config/pull/624
 [#625]: https://github.com/ergebnis/php-cs-fixer-config/pull/625
 [#626]: https://github.com/ergebnis/php-cs-fixer-config/pull/626
+[#627]: https://github.com/ergebnis/php-cs-fixer-config/pull/627
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -694,6 +694,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'throw',
                 'trait',
                 'try',
+                'type_colon',
                 'use',
                 'use_lambda',
                 'use_trait',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -694,6 +694,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'throw',
                 'trait',
                 'try',
+                'type_colon',
                 'use',
                 'use_lambda',
                 'use_trait',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -697,6 +697,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'throw',
                 'trait',
                 'try',
+                'type_colon',
                 'use',
                 'use_lambda',
                 'use_trait',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -700,6 +700,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'throw',
                 'trait',
                 'try',
+                'type_colon',
                 'use',
                 'use_lambda',
                 'use_trait',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -700,6 +700,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'throw',
                 'trait',
                 'try',
+                'type_colon',
                 'use',
                 'use_lambda',
                 'use_trait',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -703,6 +703,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'throw',
                 'trait',
                 'try',
+                'type_colon',
                 'use',
                 'use_lambda',
                 'use_trait',


### PR DESCRIPTION
This pull request

- [x] configures the`single_space_after_construct` fixer to include `type_colon` in `constructs` option

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/language_construct/single_space_after_construct.rst.