### PR TITLE
Enhancement: Configure `phpdoc_order_by_value` fixer to include `mixin` in `annotations` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`4.4.0...main`][4.4.0...main].
 - Configured `no_unneeded_control_parentheses` fixer to include `negative_instanceof` and `others` in the `statements` option ([#625]), by [@localheinz]
 - Configured `trailing_comma_in_multiline` fixer to include `match` in the `elements` option ([#626]), by [@localheinz]
 - Configured `single_space_after_construct` fixer to include `type_colon` in the `constructs` option ([#627]), by [@localheinz]
+- Configured `phpdoc_order_by_value` fixer to include `mixin` in the `annotations` option ([#628]), by [@localheinz]
 
 ## [`4.4.0`][4.4.0]
 
@@ -653,6 +654,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#625]: https://github.com/ergebnis/php-cs-fixer-config/pull/625
 [#626]: https://github.com/ergebnis/php-cs-fixer-config/pull/626
 [#627]: https://github.com/ergebnis/php-cs-fixer-config/pull/627
+[#628]: https://github.com/ergebnis/php-cs-fixer-config/pull/628
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -534,6 +534,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'group',
                 'internal',
                 'method',
+                'mixin',
                 'property',
                 'property-read',
                 'property-write',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -534,6 +534,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'group',
                 'internal',
                 'method',
+                'mixin',
                 'property',
                 'property-read',
                 'property-write',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -535,6 +535,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'group',
                 'internal',
                 'method',
+                'mixin',
                 'property',
                 'property-read',
                 'property-write',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -540,6 +540,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'group',
                 'internal',
                 'method',
+                'mixin',
                 'property',
                 'property-read',
                 'property-write',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -540,6 +540,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'group',
                 'internal',
                 'method',
+                'mixin',
                 'property',
                 'property-read',
                 'property-write',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -541,6 +541,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'group',
                 'internal',
                 'method',
+                'mixin',
                 'property',
                 'property-read',
                 'property-write',


### PR DESCRIPTION
This pull request

- [x] configures the `phpdoc_order_by_value` fixer to include `mixin` in the `annotations` option

Follows #620.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.1/doc/rules/phpdoc/phpdoc_order_by_value.rst.