### PR TITLE
Enhancement: Enable `no_multiple_statements_per_line` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`4.5.3...main`][4.5.3...main].
+For a full diff see [`4.6.0...main`][4.6.0...main].
+
+## [`4.6.0`][4.6.0]
+
+For a full diff see [`4.5.3...4.6.0`][4.5.3...4.6.0].
+
+### Changed
+
+- Enabled `no_multiple_statements_per_line` fixer ([#637]), by [@localheinz]
 
 ### Fixed
 
@@ -522,6 +530,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [4.5.1]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.5.1
 [4.5.2]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.5.2
 [4.5.3]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.5.3
+[4.6.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.6.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -567,7 +576,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [4.5.0...4.5.1]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.0...4.5.1
 [4.5.1...4.5.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.1...4.5.2
 [4.5.2...4.5.3]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.2...4.5.3
-[4.5.3...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.3...main
+[4.5.3...4.6.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.3...4.6.0
+[4.6.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.6.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -701,6 +711,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#632]: https://github.com/ergebnis/php-cs-fixer-config/pull/632
 [#633]: https://github.com/ergebnis/php-cs-fixer-config/pull/633
 [#636]: https://github.com/ergebnis/php-cs-fixer-config/pull/636
+[#637]: https://github.com/ergebnis/php-cs-fixer-config/pull/637
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -319,7 +319,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'use' => 'echo',
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiple_statements_per_line' => false,
+        'no_multiple_statements_per_line' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -320,7 +320,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'use' => 'echo',
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiple_statements_per_line' => false,
+        'no_multiple_statements_per_line' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -320,7 +320,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'use' => 'echo',
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiple_statements_per_line' => false,
+        'no_multiple_statements_per_line' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -325,7 +325,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'use' => 'echo',
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiple_statements_per_line' => false,
+        'no_multiple_statements_per_line' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -326,7 +326,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'use' => 'echo',
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiple_statements_per_line' => false,
+        'no_multiple_statements_per_line' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -326,7 +326,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'use' => 'echo',
         ],
         'no_multiline_whitespace_around_double_arrow' => true,
-        'no_multiple_statements_per_line' => false,
+        'no_multiple_statements_per_line' => true,
         'no_null_property_initialization' => true,
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `no_multiple_statements_per_line` fixer

Follows #636.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.9.5/doc/rules/basic/no_multiple_statements_per_line.rst.