### PR TITLE
Enhancement: Configure `phpdoc_order` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.6.0...main`][4.6.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#642]), by [@dependabot]
+- Configured `phpdoc_order` fixer ([#643]), by [@localheinz]
 
 ## [`4.6.0`][4.6.0]
 
@@ -717,6 +718,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#636]: https://github.com/ergebnis/php-cs-fixer-config/pull/636
 [#637]: https://github.com/ergebnis/php-cs-fixer-config/pull/637
 [#642]: https://github.com/ergebnis/php-cs-fixer-config/pull/642
+[#643]: https://github.com/ergebnis/php-cs-fixer-config/pull/643
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -524,7 +524,13 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -525,7 +525,13 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -526,7 +526,13 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -530,7 +530,13 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -531,7 +531,13 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -532,7 +532,13 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',


### PR DESCRIPTION
This pull request

- [x] configures the `phpdoc_order` fixer

Follows #642.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.10.0/doc/rules/phpdoc/phpdoc_order.rst.