### PR TITLE
Fix: Require all configurable rules to be explicitly configured when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`4.6.0...main`][4.6.0...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#642]), by [@dependabot]
 
+### Fixed
+
+- Require all configurable rules to be explicitly configured when enabled and part of an `ExplicitRuleSet` ([#644]), by [@localheinz]
+
 ## [`4.6.0`][4.6.0]
 
 For a full diff see [`4.5.3...4.6.0`][4.5.3...4.6.0].
@@ -717,6 +721,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#636]: https://github.com/ergebnis/php-cs-fixer-config/pull/636
 [#637]: https://github.com/ergebnis/php-cs-fixer-config/pull/637
 [#642]: https://github.com/ergebnis/php-cs-fixer-config/pull/642
+[#644]: https://github.com/ergebnis/php-cs-fixer-config/pull/644
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -25,9 +25,4 @@
       <code>registerBuiltInFixers</code>
     </InternalMethod>
   </file>
-  <file src="test/Unit/RuleSet/ExplicitRuleSetTestCase.php">
-    <MissingClosureReturnType occurrences="1">
-      <code>static function (FixerConfiguration\FixerOptionInterface $fixerOption) {</code>
-    </MissingClosureReturnType>
-  </file>
 </files>

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -524,7 +524,13 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -276,7 +276,10 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'strict' => false,
         ],
         'native_function_type_declaration_casing' => true,
-        'new_with_braces' => true,
+        'new_with_braces' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
         'no_alias_functions' => [
             'sets' => [
                 '@IMAP',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -284,7 +284,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'no_alias_language_construct_call' => true,
-        'no_alternative_syntax' => true,
+        'no_alternative_syntax' => [
+            'fix_non_monolithic_code' => false,
+        ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -746,7 +746,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'void_return' => true,
-        'whitespace_after_comma_in_array' => true,
+        'whitespace_after_comma_in_array' => [
+            'ensure_single_space' => false,
+        ],
         'yoda_style' => [
             'always_move_variable' => true,
             'equal' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -631,7 +631,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'property',
             ],
         ],
-        'single_import_per_statement' => true,
+        'single_import_per_statement' => [
+            'group_to_single_imports' => true,
+        ],
         'single_line_after_imports' => true,
         'single_line_comment_spacing' => true,
         'single_line_comment_style' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -525,7 +525,13 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -276,7 +276,10 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'strict' => false,
         ],
         'native_function_type_declaration_casing' => true,
-        'new_with_braces' => true,
+        'new_with_braces' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
         'no_alias_functions' => [
             'sets' => [
                 '@IMAP',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -284,7 +284,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'no_alias_language_construct_call' => true,
-        'no_alternative_syntax' => true,
+        'no_alternative_syntax' => [
+            'fix_non_monolithic_code' => false,
+        ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -749,7 +749,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'void_return' => true,
-        'whitespace_after_comma_in_array' => true,
+        'whitespace_after_comma_in_array' => [
+            'ensure_single_space' => false,
+        ],
         'yoda_style' => [
             'always_move_variable' => true,
             'equal' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -632,7 +632,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'property',
             ],
         ],
-        'single_import_per_statement' => true,
+        'single_import_per_statement' => [
+            'group_to_single_imports' => true,
+        ],
         'single_line_after_imports' => true,
         'single_line_comment_spacing' => true,
         'single_line_comment_style' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -276,7 +276,10 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'strict' => false,
         ],
         'native_function_type_declaration_casing' => true,
-        'new_with_braces' => true,
+        'new_with_braces' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
         'no_alias_functions' => [
             'sets' => [
                 '@IMAP',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -633,7 +633,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'property',
             ],
         ],
-        'single_import_per_statement' => true,
+        'single_import_per_statement' => [
+            'group_to_single_imports' => true,
+        ],
         'single_line_after_imports' => true,
         'single_line_comment_spacing' => true,
         'single_line_comment_style' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -526,7 +526,13 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -284,7 +284,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'no_alias_language_construct_call' => true,
-        'no_alternative_syntax' => true,
+        'no_alternative_syntax' => [
+            'fix_non_monolithic_code' => false,
+        ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -752,7 +752,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'void_return' => true,
-        'whitespace_after_comma_in_array' => true,
+        'whitespace_after_comma_in_array' => [
+            'ensure_single_space' => false,
+        ],
         'yoda_style' => [
             'always_move_variable' => true,
             'equal' => true,

--- a/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
+++ b/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
@@ -86,8 +86,8 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
         $rulesWithAllNonDeprecatedConfigurationOptions = \array_combine(
             $namesOfRules,
             \array_map(static function (string $nameOfRule, $ruleConfiguration) use ($fixersThatAreBuiltIn) {
-                if (!\is_array($ruleConfiguration)) {
-                    return $ruleConfiguration;
+                if (false === $ruleConfiguration) {
+                    return false;
                 }
 
                 $fixer = $fixersThatAreBuiltIn[$nameOfRule];
@@ -106,15 +106,25 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
                     return !$fixerOption instanceof FixerConfiguration\DeprecatedFixerOptionInterface;
                 });
 
+                $ruleConfigurationWithAllNonDeprecatedConfigurationOptionsAndDefaultValues = \array_combine(
+                    \array_map(static function (FixerConfiguration\FixerOptionInterface $fixerOption): string {
+                        return $fixerOption->getName();
+                    }, $nonDeprecatedConfigurationOptions),
+                    \array_map(static function (FixerConfiguration\FixerOptionInterface $fixerOption) {
+                        if (!$fixerOption->hasDefault()) {
+                            return null;
+                        }
+
+                        return $fixerOption->getDefault();
+                    }, $nonDeprecatedConfigurationOptions),
+                );
+
+                if (!\is_array($ruleConfiguration)) {
+                    return $ruleConfigurationWithAllNonDeprecatedConfigurationOptionsAndDefaultValues;
+                }
+
                 $diff = \array_diff_key(
-                    \array_combine(
-                        \array_map(static function (FixerConfiguration\FixerOptionInterface $fixerOption): string {
-                            return $fixerOption->getName();
-                        }, $nonDeprecatedConfigurationOptions),
-                        \array_map(static function (FixerConfiguration\FixerOptionInterface $fixerOption) {
-                            return $fixerOption->getDefault();
-                        }, $nonDeprecatedConfigurationOptions),
-                    ),
+                    $ruleConfigurationWithAllNonDeprecatedConfigurationOptionsAndDefaultValues,
                     $ruleConfiguration,
                 );
 

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -282,7 +282,10 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'strict' => false,
         ],
         'native_function_type_declaration_casing' => true,
-        'new_with_braces' => true,
+        'new_with_braces' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
         'no_alias_functions' => [
             'sets' => [
                 '@IMAP',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -530,7 +530,13 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -637,7 +637,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'property',
             ],
         ],
-        'single_import_per_statement' => true,
+        'single_import_per_statement' => [
+            'group_to_single_imports' => true,
+        ],
         'single_line_after_imports' => true,
         'single_line_comment_spacing' => true,
         'single_line_comment_style' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -752,7 +752,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
         ],
         'void_return' => true,
-        'whitespace_after_comma_in_array' => true,
+        'whitespace_after_comma_in_array' => [
+            'ensure_single_space' => false,
+        ],
         'yoda_style' => [
             'always_move_variable' => true,
             'equal' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -290,7 +290,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
         ],
         'no_alias_language_construct_call' => true,
-        'no_alternative_syntax' => true,
+        'no_alternative_syntax' => [
+            'fix_non_monolithic_code' => false,
+        ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -755,7 +755,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
         ],
         'void_return' => true,
-        'whitespace_after_comma_in_array' => true,
+        'whitespace_after_comma_in_array' => [
+            'ensure_single_space' => false,
+        ],
         'yoda_style' => [
             'always_move_variable' => true,
             'equal' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -638,7 +638,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'property',
             ],
         ],
-        'single_import_per_statement' => true,
+        'single_import_per_statement' => [
+            'group_to_single_imports' => true,
+        ],
         'single_line_after_imports' => true,
         'single_line_comment_spacing' => true,
         'single_line_comment_style' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -282,7 +282,10 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'strict' => false,
         ],
         'native_function_type_declaration_casing' => true,
-        'new_with_braces' => true,
+        'new_with_braces' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
         'no_alias_functions' => [
             'sets' => [
                 '@IMAP',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -531,7 +531,13 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -290,7 +290,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
         ],
         'no_alias_language_construct_call' => true,
-        'no_alternative_syntax' => true,
+        'no_alternative_syntax' => [
+            'fix_non_monolithic_code' => false,
+        ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -290,7 +290,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
         ],
         'no_alias_language_construct_call' => true,
-        'no_alternative_syntax' => true,
+        'no_alternative_syntax' => [
+            'fix_non_monolithic_code' => false,
+        ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -639,7 +639,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'property',
             ],
         ],
-        'single_import_per_statement' => true,
+        'single_import_per_statement' => [
+            'group_to_single_imports' => true,
+        ],
         'single_line_after_imports' => true,
         'single_line_comment_spacing' => true,
         'single_line_comment_style' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -532,7 +532,13 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param',
+                'throws',
+                'return',
+            ],
+        ],
         'phpdoc_order_by_value' => [
             'annotations' => [
                 'author',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -758,7 +758,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
         ],
         'void_return' => true,
-        'whitespace_after_comma_in_array' => true,
+        'whitespace_after_comma_in_array' => [
+            'ensure_single_space' => false,
+        ],
         'yoda_style' => [
             'always_move_variable' => true,
             'equal' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -282,7 +282,10 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'strict' => false,
         ],
         'native_function_type_declaration_casing' => true,
-        'new_with_braces' => true,
+        'new_with_braces' => [
+            'anonymous_class' => true,
+            'named_class' => true,
+        ],
         'no_alias_functions' => [
             'sets' => [
                 '@IMAP',


### PR DESCRIPTION
This pull request

- [x] requires all configurable rules to be explicitly configured when enabled
- [x] explicitly configures all rules that are enabled and part of `ExplicitRuleSet`s

Follows #642.