### PR TITLE
Enhancement: Enable `ensure_single_space` option of `whitespace_after_comma_in_array` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.6.0...main`][4.6.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#642]), by [@dependabot]
+- Configured the `whitespace_after_comma_in_array` fixer to ensure a single space using the `'ensure_single_space` option ([#645]), by [@localheinz]
 
 ### Fixed
 
@@ -722,6 +723,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#637]: https://github.com/ergebnis/php-cs-fixer-config/pull/637
 [#642]: https://github.com/ergebnis/php-cs-fixer-config/pull/642
 [#644]: https://github.com/ergebnis/php-cs-fixer-config/pull/644
+[#645]: https://github.com/ergebnis/php-cs-fixer-config/pull/645
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -760,7 +760,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'void_return' => true,
         'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => false,
+            'ensure_single_space' => true,
         ],
         'yoda_style' => [
             'always_move_variable' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -763,7 +763,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'void_return' => true,
         'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => false,
+            'ensure_single_space' => true,
         ],
         'yoda_style' => [
             'always_move_variable' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -766,7 +766,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'void_return' => true,
         'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => false,
+            'ensure_single_space' => true,
         ],
         'yoda_style' => [
             'always_move_variable' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -766,7 +766,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'void_return' => true,
         'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => false,
+            'ensure_single_space' => true,
         ],
         'yoda_style' => [
             'always_move_variable' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -769,7 +769,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'void_return' => true,
         'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => false,
+            'ensure_single_space' => true,
         ],
         'yoda_style' => [
             'always_move_variable' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -772,7 +772,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ],
         'void_return' => true,
         'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => false,
+            'ensure_single_space' => true,
         ],
         'yoda_style' => [
             'always_move_variable' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `ensure_single_space` option of `whitespace_after_comma_in_array` fixer

Follows #642.