### PR TITLE
Enhancement: Enable `fix_non_monolithic_code` option of `no_alternative_syntax` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`4.6.0...main`][4.6.0...main].
+For a full diff see [`4.7.0...main`][4.7.0...main].
+
+## [`4.7.0`][4.7.0]
+
+For a full diff see [`4.6.0...4.7.0`][4.6.0...4.7.0].
 
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#642]), by [@dependabot]
 - Configured the `whitespace_after_comma_in_array` fixer to ensure a single space using the `ensure_single_space` option ([#645]), by [@localheinz]
+- Configured the `no_alternative_syntax` fixer to ensure a single space using the `fix_non_monolithic_code` option ([#646]), by [@localheinz]
 
 ### Fixed
 
@@ -540,6 +545,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [4.5.2]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.5.2
 [4.5.3]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.5.3
 [4.6.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.6.0
+[4.7.0]: https://github.com/ergebnis/php-cs-fixer-config/releases/tag/4.7.0
 
 [d899e77...1.0.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/d899e77...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/1.0.0...1.1.0
@@ -586,7 +592,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [4.5.1...4.5.2]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.1...4.5.2
 [4.5.2...4.5.3]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.2...4.5.3
 [4.5.3...4.6.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.3...4.6.0
-[4.6.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.6.0...main
+[4.6.0...4.7.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.6.0...4.7.0
+[4.7.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.7.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -724,6 +731,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#642]: https://github.com/ergebnis/php-cs-fixer-config/pull/642
 [#644]: https://github.com/ergebnis/php-cs-fixer-config/pull/644
 [#645]: https://github.com/ergebnis/php-cs-fixer-config/pull/645
+[#646]: https://github.com/ergebnis/php-cs-fixer-config/pull/646
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -288,7 +288,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => [
-            'fix_non_monolithic_code' => false,
+            'fix_non_monolithic_code' => true,
         ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -288,7 +288,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => [
-            'fix_non_monolithic_code' => false,
+            'fix_non_monolithic_code' => true,
         ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -288,7 +288,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => [
-            'fix_non_monolithic_code' => false,
+            'fix_non_monolithic_code' => true,
         ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -294,7 +294,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => [
-            'fix_non_monolithic_code' => false,
+            'fix_non_monolithic_code' => true,
         ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -294,7 +294,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => [
-            'fix_non_monolithic_code' => false,
+            'fix_non_monolithic_code' => true,
         ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -294,7 +294,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ],
         'no_alias_language_construct_call' => true,
         'no_alternative_syntax' => [
-            'fix_non_monolithic_code' => false,
+            'fix_non_monolithic_code' => true,
         ],
         'no_binary_string' => true,
         'no_blank_lines_after_class_opening' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `fix_non_monolithic_code` option of `no_alternative_syntax` fixer

Follows #642.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.10.0/doc/rules/control_structure/no_alternative_syntax.rst.