### PR TITLE
Enhancement: Configure `no_trailing_comma_in_singleline` fixer to include `group_import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`4.8.0...main`][4.8.0...main].
+For a full diff see [`4.9.0...main`][4.9.0...main].
+
+## [`4.9.0`][4.9.0]
+
+For a full diff see [`4.8.0...4.9.0`][4.7.0...4.9.0].
+
+### Changed
+
+- Configured `no_trailing_comma_in_singleline` fixer to include `group_import`  ([#655]), by [@dependabot]
 
 ## [`4.8.0`][4.8.0]
 
@@ -603,7 +611,8 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [4.5.3...4.6.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.5.3...4.6.0
 [4.6.0...4.7.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.6.0...4.7.0
 [4.7.0...4.8.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.7.0...4.8.0
-[4.8.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.8.0...main
+[4.8.0...4.9.0]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.8.0...4.9.0
+[4.9.0...main]: https://github.com/ergebnis/php-cs-fixer-config/compare/4.9.0...main
 
 [#3]: https://github.com/ergebnis/php-cs-fixer-config/pull/3
 [#14]: https://github.com/ergebnis/php-cs-fixer-config/pull/14
@@ -743,6 +752,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#645]: https://github.com/ergebnis/php-cs-fixer-config/pull/645
 [#646]: https://github.com/ergebnis/php-cs-fixer-config/pull/646
 [#651]: https://github.com/ergebnis/php-cs-fixer-config/pull/651
+[#655]: https://github.com/ergebnis/php-cs-fixer-config/pull/655
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -349,6 +349,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'arguments',
                 'array',
                 'array_destructuring',
+                'group_import',
             ],
         ],
         'no_trailing_whitespace' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -350,6 +350,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'arguments',
                 'array',
                 'array_destructuring',
+                'group_import',
             ],
         ],
         'no_trailing_whitespace' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -350,6 +350,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'arguments',
                 'array',
                 'array_destructuring',
+                'group_import',
             ],
         ],
         'no_trailing_whitespace' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -355,6 +355,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'arguments',
                 'array',
                 'array_destructuring',
+                'group_import',
             ],
         ],
         'no_trailing_whitespace' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -356,6 +356,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'arguments',
                 'array',
                 'array_destructuring',
+                'group_import',
             ],
         ],
         'no_trailing_whitespace' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -356,6 +356,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'arguments',
                 'array',
                 'array_destructuring',
+                'group_import',
             ],
         ],
         'no_trailing_whitespace' => true,


### PR DESCRIPTION
This pull request

- [x] configures the `no_trailing_comma_in_singleline` fixer to include `group_import`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.11.0/doc/rules/basic/no_trailing_comma_in_singleline.rst.