### PR TITLE
Enhancement: Enable and configure `no_useless_concat_operator` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.9.0...main`][4.9.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#661]), by [@dependabot]
+- Enabled and configured `no_useless_concat_operator` fixer ([#662]), by [@localheinz]
 
 ## [`4.9.0`][4.9.0]
 
@@ -758,6 +759,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#651]: https://github.com/ergebnis/php-cs-fixer-config/pull/651
 [#655]: https://github.com/ergebnis/php-cs-fixer-config/pull/655
 [#661]: https://github.com/ergebnis/php-cs-fixer-config/pull/661
+[#662]: https://github.com/ergebnis/php-cs-fixer-config/pull/662
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -380,7 +380,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
-        'no_useless_concat_operator' => false,
+        'no_useless_concat_operator' => [
+            'juggle_simple_strings' => true,
+        ],
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => false,
         'no_useless_return' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -381,7 +381,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
-        'no_useless_concat_operator' => false,
+        'no_useless_concat_operator' => [
+            'juggle_simple_strings' => true,
+        ],
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -381,7 +381,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
-        'no_useless_concat_operator' => false,
+        'no_useless_concat_operator' => [
+            'juggle_simple_strings' => true,
+        ],
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -386,7 +386,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
-        'no_useless_concat_operator' => false,
+        'no_useless_concat_operator' => [
+            'juggle_simple_strings' => true,
+        ],
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => false,
         'no_useless_return' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -387,7 +387,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
-        'no_useless_concat_operator' => false,
+        'no_useless_concat_operator' => [
+            'juggle_simple_strings' => true,
+        ],
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -387,7 +387,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'no_unset_cast' => true,
         'no_unset_on_property' => true,
         'no_unused_imports' => true,
-        'no_useless_concat_operator' => false,
+        'no_useless_concat_operator' => [
+            'juggle_simple_strings' => true,
+        ],
         'no_useless_else' => true,
         'no_useless_nullsafe_operator' => true,
         'no_useless_return' => true,


### PR DESCRIPTION
This pull request

- [x] enables and configures the `no_useless_concat_operator` fixer

Follows #661.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.12.0/doc/rules/operator/no_useless_concat_operator.rst.