### PR TITLE
Enhancement: Configure `phpdoc_order` fixer to order additional annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`5.1.1...main`][5.1.1...main].
 
+### Changed
+
+- Configured the `phpdoc_order` fixer to order additional annotations ([#694]), by [@localheinz]
+
 ## [`5.1.1`][5.1.1]
 
 For a full diff see [`5.1.0...5.1.1`][5.1.0...5.1.1].
@@ -826,6 +830,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#673]: https://github.com/ergebnis/php-cs-fixer-config/pull/673
 [#684]: https://github.com/ergebnis/php-cs-fixer-config/pull/684
 [#693]: https://github.com/ergebnis/php-cs-fixer-config/pull/693
+[#694]: https://github.com/ergebnis/php-cs-fixer-config/pull/694
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -541,6 +541,11 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => [
             'order' => [
+                'deprecated',
+                'internal',
+                'covers',
+                'uses',
+                'dataProvider',
                 'param',
                 'throws',
                 'return',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -542,6 +542,11 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => [
             'order' => [
+                'deprecated',
+                'internal',
+                'covers',
+                'uses',
+                'dataProvider',
                 'param',
                 'throws',
                 'return',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -542,6 +542,11 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => [
             'order' => [
+                'deprecated',
+                'internal',
+                'covers',
+                'uses',
+                'dataProvider',
                 'param',
                 'throws',
                 'return',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -547,6 +547,11 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => [
             'order' => [
+                'deprecated',
+                'internal',
+                'covers',
+                'uses',
+                'dataProvider',
                 'param',
                 'throws',
                 'return',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -548,6 +548,11 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => [
             'order' => [
+                'deprecated',
+                'internal',
+                'covers',
+                'uses',
+                'dataProvider',
                 'param',
                 'throws',
                 'return',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -548,6 +548,11 @@ final class Php82Test extends ExplicitRuleSetTestCase
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => [
             'order' => [
+                'deprecated',
+                'internal',
+                'covers',
+                'uses',
+                'dataProvider',
                 'param',
                 'throws',
                 'return',


### PR DESCRIPTION
This pull request

- [x] configures the `phpdoc_order` fixer to order additional annotations