### PR TITLE
Enhancement: Enable `php_unit_data_provider_static` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`5.2.0...main`][5.2.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#710]), by [@dependabot]
+- Enabled `no_multiple_statements_per_line` fixer ([#711]), by [@localheinz]
 
 ## [`5.2.0`][5.2.0]
 

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -448,7 +448,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'assertSame',
             ],
         ],
-        'php_unit_data_provider_static' => false,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => [
             'target' => 'newest',
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -449,7 +449,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'assertSame',
             ],
         ],
-        'php_unit_data_provider_static' => false,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => [
             'target' => 'newest',
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -449,7 +449,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
                 'assertSame',
             ],
         ],
-        'php_unit_data_provider_static' => false,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => [
             'target' => 'newest',
         ],

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -74,7 +74,7 @@ final class FactoryTest extends Framework\TestCase
     /**
      * @return \Generator<int, array{0: int}>
      */
-    public function provideTargetPhpVersion(): \Generator
+    public static function provideTargetPhpVersion(): \Generator
     {
         $values = [
             \PHP_VERSION_ID - 1,

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -295,7 +295,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     /**
      * @return \Generator<string, array{0: string}>
      */
-    final public function provideValidHeader(): \Generator
+    final public static function provideValidHeader(): \Generator
     {
         $values = [
             'string-empty' => '',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -454,7 +454,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'assertSame',
             ],
         ],
-        'php_unit_data_provider_static' => false,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -455,7 +455,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'assertSame',
             ],
         ],
-        'php_unit_data_provider_static' => false,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => [
             'target' => 'newest',
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -455,7 +455,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'assertSame',
             ],
         ],
-        'php_unit_data_provider_static' => false,
+        'php_unit_data_provider_static' => true,
         'php_unit_dedicate_assert' => [
             'target' => 'newest',
         ],


### PR DESCRIPTION
This pull request

- [x] enables the `php_unit_data_provider_static` fixer

Follows #710.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.14.0/doc/rules/php_unit/php_unit_data_provider_static.rst.