### PR TITLE
Enhancement: Configure `constructs_contain_a_single_space` option of `single_space_around_construct` fixer for `yield from` constructs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`5.3.3...main`][5.3.3...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#746]), by [@dependabot]
 - Enabled and configured the `single_space_around_construct` fixer as a replacement for the deprecated `single_space_after_construct` fixer ([#746]), by [@localheinz]
+- Configured `constructs_contain_a_single_space` option of the `single_space_around_construct` fixer to enforce a single space in `yield from` constructs ([#747]), by [@localheinz]
 
 ### Fixed
 
@@ -894,6 +895,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#737]: https://github.com/ergebnis/php-cs-fixer-config/pull/737
 [#738]: https://github.com/ergebnis/php-cs-fixer-config/pull/738
 [#746]: https://github.com/ergebnis/php-cs-fixer-config/pull/746
+[#747]: https://github.com/ergebnis/php-cs-fixer-config/pull/747
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -693,7 +693,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'strings_containing_single_quote_chars' => false,
         ],
         'single_space_around_construct' => [
-            'constructs_contain_a_single_space' => [],
+            'constructs_contain_a_single_space' => [
+                'yield_from',
+            ],
             'constructs_followed_by_a_single_space' => [
                 'abstract',
                 'as',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -694,7 +694,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'strings_containing_single_quote_chars' => false,
         ],
         'single_space_around_construct' => [
-            'constructs_contain_a_single_space' => [],
+            'constructs_contain_a_single_space' => [
+                'yield_from',
+            ],
             'constructs_followed_by_a_single_space' => [
                 'abstract',
                 'as',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -694,7 +694,9 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'strings_containing_single_quote_chars' => false,
         ],
         'single_space_around_construct' => [
-            'constructs_contain_a_single_space' => [],
+            'constructs_contain_a_single_space' => [
+                'yield_from',
+            ],
             'constructs_followed_by_a_single_space' => [
                 'abstract',
                 'as',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -699,7 +699,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'strings_containing_single_quote_chars' => false,
         ],
         'single_space_around_construct' => [
-            'constructs_contain_a_single_space' => [],
+            'constructs_contain_a_single_space' => [
+                'yield_from',
+            ],
             'constructs_followed_by_a_single_space' => [
                 'abstract',
                 'as',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -700,7 +700,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'strings_containing_single_quote_chars' => false,
         ],
         'single_space_around_construct' => [
-            'constructs_contain_a_single_space' => [],
+            'constructs_contain_a_single_space' => [
+                'yield_from',
+            ],
             'constructs_followed_by_a_single_space' => [
                 'abstract',
                 'as',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -700,7 +700,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'strings_containing_single_quote_chars' => false,
         ],
         'single_space_around_construct' => [
-            'constructs_contain_a_single_space' => [],
+            'constructs_contain_a_single_space' => [
+                'yield_from',
+            ],
             'constructs_followed_by_a_single_space' => [
                 'abstract',
                 'as',


### PR DESCRIPTION
This pull request

- [x] configures the `constructs_contain_a_single_space` option of the `single_space_around_construct` fixer for `yield from` constructs

Follows #746.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.16.0/doc/rules/language_construct/single_space_around_construct.rst.