### PR TITLE
Fix: Configure `constructs_preceded_by_a_single_space` option of `single_space_around_construct` fixer to retain previous configuration

### DIFF
--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -758,7 +758,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'yield',
                 'yield_from',
             ],
-            'constructs_preceded_by_a_single_space' => [],
+            'constructs_preceded_by_a_single_space' => [
+                'use_lambda',
+            ],
         ],
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -760,7 +760,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'yield',
                 'yield_from',
             ],
-            'constructs_preceded_by_a_single_space' => [],
+            'constructs_preceded_by_a_single_space' => [
+                'use_lambda',
+            ],
         ],
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -760,7 +760,9 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
                 'yield',
                 'yield_from',
             ],
-            'constructs_preceded_by_a_single_space' => [],
+            'constructs_preceded_by_a_single_space' => [
+                'use_lambda',
+            ],
         ],
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -764,7 +764,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'yield',
                 'yield_from',
             ],
-            'constructs_preceded_by_a_single_space' => [],
+            'constructs_preceded_by_a_single_space' => [
+                'use_lambda',
+            ],
         ],
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -766,7 +766,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'yield',
                 'yield_from',
             ],
-            'constructs_preceded_by_a_single_space' => [],
+            'constructs_preceded_by_a_single_space' => [
+                'use_lambda',
+            ],
         ],
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -766,7 +766,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'yield',
                 'yield_from',
             ],
-            'constructs_preceded_by_a_single_space' => [],
+            'constructs_preceded_by_a_single_space' => [
+                'use_lambda',
+            ],
         ],
         'single_trait_insert_per_statement' => true,
         'space_after_semicolon' => [


### PR DESCRIPTION
This pull request

- [x] configures the `constructs_preceded_by_a_single_space` option of the `single_space_around_construct` fixer to retain the previous configuration of the deprecated `braces `fixer`

Follows #746.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.16.0/doc/rules/language_construct/single_space_around_construct.rst.