### PR TITLE
Enhancement: Configure `phpdoc_separation` fixer to group `@deprecated` annotations into a separate group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`5.4.0...main`][5.4.0...main].
 
+### Changed
+
+- Configured `phpdoc_separation` fixer to group `@deprecated` annotations into a separate group ([#751]), by [@localheinz]
+
 ## [`5.4.0`][5.4.0]
 
 For a full diff see [`5.3.3...5.4.0`][5.3.3...5.4.0].
@@ -904,6 +908,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#746]: https://github.com/ergebnis/php-cs-fixer-config/pull/746
 [#747]: https://github.com/ergebnis/php-cs-fixer-config/pull/747
 [#748]: https://github.com/ergebnis/php-cs-fixer-config/pull/748
+[#751]: https://github.com/ergebnis/php-cs-fixer-config/pull/751
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -590,6 +590,8 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'groups' => [
                 [
                     'deprecated',
+                ],
+                [
                     'link',
                     'see',
                     'since',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -591,6 +591,8 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'groups' => [
                 [
                     'deprecated',
+                ],
+                [
                     'link',
                     'see',
                     'since',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -591,6 +591,8 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'groups' => [
                 [
                     'deprecated',
+                ],
+                [
                     'link',
                     'see',
                     'since',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -596,6 +596,8 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'groups' => [
                 [
                     'deprecated',
+                ],
+                [
                     'link',
                     'see',
                     'since',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -597,6 +597,8 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'groups' => [
                 [
                     'deprecated',
+                ],
+                [
                     'link',
                     'see',
                     'since',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -597,6 +597,8 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'groups' => [
                 [
                     'deprecated',
+                ],
+                [
                     'link',
                     'see',
                     'since',


### PR DESCRIPTION
This pull request

- [x] configures the `phpdoc_separation` fixer to group `@deprecated` annotations into a separate group

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.16.0/doc/rules/phpdoc/phpdoc_separation.rst.