### PR TITLE
Fix: Disable `php_unit_internal_class` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`5.5.0...main`][5.5.0...main].
 
+### Changed
+
+- Disabled `php_unit_internal_class` fixer ([#764]), by [@localheinz]
+
+
 ## [`5.5.0`][5.5.0]
 
 For a full diff see [`5.4.0...5.5.0`][5.4.0...5.5.0].
@@ -915,6 +920,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#747]: https://github.com/ergebnis/php-cs-fixer-config/pull/747
 [#748]: https://github.com/ergebnis/php-cs-fixer-config/pull/748
 [#751]: https://github.com/ergebnis/php-cs-fixer-config/pull/751
+[#764]: https://github.com/ergebnis/php-cs-fixer-config/pull/764
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -454,13 +454,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => [
-            'types' => [
-                'abstract',
-                'final',
-                'normal',
-            ],
-        ],
+        'php_unit_internal_class' => false,
         'php_unit_method_casing' => [
             'case' => 'camel_case',
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -455,13 +455,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => [
-            'types' => [
-                'abstract',
-                'final',
-                'normal',
-            ],
-        ],
+        'php_unit_internal_class' => false,
         'php_unit_method_casing' => [
             'case' => 'camel_case',
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -455,13 +455,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => [
-            'types' => [
-                'abstract',
-                'final',
-                'normal',
-            ],
-        ],
+        'php_unit_internal_class' => false,
         'php_unit_method_casing' => [
             'case' => 'camel_case',
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -460,13 +460,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => [
-            'types' => [
-                'abstract',
-                'final',
-                'normal',
-            ],
-        ],
+        'php_unit_internal_class' => false,
         'php_unit_method_casing' => [
             'case' => 'camel_case',
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -461,13 +461,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => [
-            'types' => [
-                'abstract',
-                'final',
-                'normal',
-            ],
-        ],
+        'php_unit_internal_class' => false,
         'php_unit_method_casing' => [
             'case' => 'camel_case',
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -461,13 +461,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'target' => 'newest',
         ],
         'php_unit_fqcn_annotation' => true,
-        'php_unit_internal_class' => [
-            'types' => [
-                'abstract',
-                'final',
-                'normal',
-            ],
-        ],
+        'php_unit_internal_class' => false,
         'php_unit_method_casing' => [
             'case' => 'camel_case',
         ],


### PR DESCRIPTION
This pull request

- [x] disables the `php_unit_internal_class` fixer as it does not make sense to have a DocBlock and PHPUnit 10 attributes

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.16.0/doc/rules/php_unit/php_unit_internal_class.rst.