### PR TITLE
Fix: Disable `php_unit_test_class_requires_covers` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`5.5.1...main`][5.5.1...main].
 
+### Changed
+
+- Disabled `php_unit_test_class_requires_covers` fixer ([#765]), by [@localheinz]
+
 ## [`5.5.1`][5.5.1]
 
 For a full diff see [`5.5.0...5.5.1`][5.5.0...5.5.1].
@@ -926,6 +930,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#748]: https://github.com/ergebnis/php-cs-fixer-config/pull/748
 [#751]: https://github.com/ergebnis/php-cs-fixer-config/pull/751
 [#764]: https://github.com/ergebnis/php-cs-fixer-config/pull/764
+[#765]: https://github.com/ergebnis/php-cs-fixer-config/pull/765
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -479,7 +479,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'call_type' => 'self',
             'methods' => [],
         ],
-        'php_unit_test_class_requires_covers' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -480,7 +480,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'call_type' => 'self',
             'methods' => [],
         ],
-        'php_unit_test_class_requires_covers' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -480,7 +480,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'call_type' => 'self',
             'methods' => [],
         ],
-        'php_unit_test_class_requires_covers' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -483,7 +483,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'call_type' => 'self',
             'methods' => [],
         ],
-        'php_unit_test_class_requires_covers' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -484,7 +484,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'call_type' => 'self',
             'methods' => [],
         ],
-        'php_unit_test_class_requires_covers' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -484,7 +484,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'call_type' => 'self',
             'methods' => [],
         ],
-        'php_unit_test_class_requires_covers' => true,
+        'php_unit_test_class_requires_covers' => false,
         'phpdoc_add_missing_param_annotation' => [
             'only_untyped' => true,
         ],


### PR DESCRIPTION
This pull request

- [x] disables the `php_unit_test_class_requires_covers` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.16.0/doc/rules/php_unit/php_unit_test_class_requires_covers.rst.