### PR TITLE
Enhancement: Enable and configure `ordered_types` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`5.6.0...main`][5.6.0...main].
 ## Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#787]), by [@dependabot]
+- Enabled and configured `ordered_types` fixer ([#788]), by [@localheinz]
 
 ## [`5.6.0`][5.6.0]
 
@@ -969,6 +970,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#785]: https://github.com/ergebnis/php-cs-fixer-config/pull/785
 [#786]: https://github.com/ergebnis/php-cs-fixer-config/pull/786
 [#787]: https://github.com/ergebnis/php-cs-fixer-config/pull/787
+[#788]: https://github.com/ergebnis/php-cs-fixer-config/pull/788
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -427,7 +427,10 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -428,7 +428,10 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -432,7 +432,10 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -432,7 +432,10 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -430,7 +430,10 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -432,7 +432,10 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -432,7 +432,10 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -432,7 +432,10 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -432,7 +432,10 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -433,7 +433,10 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -434,7 +434,10 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -434,7 +434,10 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -433,7 +433,10 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -434,7 +434,10 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -438,7 +438,10 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -438,7 +438,10 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -436,7 +436,10 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -438,7 +438,10 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -438,7 +438,10 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -438,7 +438,10 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -438,7 +438,10 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -437,7 +437,10 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -438,7 +438,10 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -438,7 +438,10 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'order' => 'alpha',
         ],
         'ordered_traits' => false,
-        'ordered_types' => false,
+        'ordered_types' => [
+            'null_adjustment' => 'always_first',
+            'sort_algorithm' => 'alpha',
+        ],
         'php_unit_construct' => [
             'assertions' => [
                 'assertEquals',


### PR DESCRIPTION
This pull request

- [x] enables and configures the `ordered_types` fixer

Follows #787.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.17.0/doc/rules/class_notation/ordered_types.rst.