### PR TITLE
Enhancement: Enable `phpdoc_param_order` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`5.6.0...main`][5.6.0...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#787]), by [@dependabot]
 - Enabled and configured `ordered_types` fixer ([#788]), by [@localheinz]
+- Enabled `phpdoc_param_order` fixer ([#789]), by [@localheinz]
 
 ## [`5.6.0`][5.6.0]
 
@@ -971,6 +972,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#786]: https://github.com/ergebnis/php-cs-fixer-config/pull/786
 [#787]: https://github.com/ergebnis/php-cs-fixer-config/pull/787
 [#788]: https://github.com/ergebnis/php-cs-fixer-config/pull/788
+[#789]: https://github.com/ergebnis/php-cs-fixer-config/pull/789
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -558,7 +558,7 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -559,7 +559,7 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -563,7 +563,7 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -563,7 +563,7 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -561,7 +561,7 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -563,7 +563,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -563,7 +563,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -563,7 +563,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -563,7 +563,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -564,7 +564,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -565,7 +565,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -565,7 +565,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -564,7 +564,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -565,7 +565,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -569,7 +569,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -569,7 +569,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -567,7 +567,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -569,7 +569,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -569,7 +569,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -569,7 +569,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -569,7 +569,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -568,7 +568,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -569,7 +569,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -569,7 +569,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'uses',
             ],
         ],
-        'phpdoc_param_order' => false,
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => [
             'replacements' => [
                 '$self' => 'self',


### PR DESCRIPTION
This pull request

- [x] enables the `phpdoc_param_order` fixer

Follows #787.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.17.0/doc/rules/phpdoc/phpdoc_param_order.rst.