### PR TITLE
Fix: Configure `blank_lines_before_namespace` instead of deprecated `single_blank_line_before_namespace` fixer

### DIFF
--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -59,7 +59,10 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -59,7 +59,10 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -61,7 +61,10 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -61,7 +61,10 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -61,7 +61,10 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -61,7 +61,10 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -61,7 +61,10 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -61,7 +61,10 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -61,7 +61,10 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -61,7 +61,10 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -61,7 +61,10 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -61,7 +61,10 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -65,7 +65,10 @@ final class Php53Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -65,7 +65,10 @@ final class Php54Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -67,7 +67,10 @@ final class Php55Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -67,7 +67,10 @@ final class Php56Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -67,7 +67,10 @@ final class Php70Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -67,7 +67,10 @@ final class Php71Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -67,7 +67,10 @@ final class Php72Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -67,7 +67,10 @@ final class Php73Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -67,7 +67,10 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -65,7 +65,10 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -65,7 +65,10 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -65,7 +65,10 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
         ],
         'blank_line_between_import_groups' => false,
-        'blank_lines_before_namespace' => false,
+        'blank_lines_before_namespace' => [
+            'max_line_breaks' => 2,
+            'min_line_breaks' => 2,
+        ],
         'cast_spaces' => [
             'space' => 'single',
         ],


### PR DESCRIPTION
This pull request

- [x] configures the `blank_lines_before_namespace` fixer instead of the deprecated `single_blank_line_before_namespace` fixer

Follows #800.