### PR TITLE
Enhancement: Enable and configure `nullable_type_declaration` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`5.10.0...main`][5.10.0...main].
 ## Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#815]), by [@dependabot]
+- Enabled and configured the `nullable_type_declaration` fixer ([#816]), by [@localheinz]
 
 ## [`5.10.0`][5.10.0]
 
@@ -1040,6 +1041,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#805]: https://github.com/ergebnis/php-cs-fixer-config/pull/805
 [#810]: https://github.com/ergebnis/php-cs-fixer-config/pull/810
 [#815]: https://github.com/ergebnis/php-cs-fixer-config/pull/815
+[#816]: https://github.com/ergebnis/php-cs-fixer-config/pull/816
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -394,7 +394,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration' => false,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -394,7 +394,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration' => false,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -394,7 +394,9 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration' => false,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -399,7 +399,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration' => false,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -399,7 +399,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration' => false,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -399,7 +399,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
         'normalize_index_brace' => true,
         'not_operator_with_space' => false,
         'not_operator_with_successor_space' => false,
-        'nullable_type_declaration' => false,
+        'nullable_type_declaration' => [
+            'syntax' => 'question_mark',
+        ],
         'nullable_type_declaration_for_default_null_value' => [
             'use_nullable_type_declaration' => true,
         ],


### PR DESCRIPTION
This pull request

- [x] enables and configures the `nullable_type_declaration` fixer

Follows #815.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.21.1/doc/rules/language_construct/nullable_type_declaration.rst.