### PR TITLE
Enhancement: Configure `type_declaration_spaces` fixer to include `property` in the `elements` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`5.10.0...main`][5.10.0...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#815]), by [@dependabot]
 - Enabled and configured the `nullable_type_declaration` fixer ([#816]), by [@localheinz]
+- Configured the `type_declaration_spaces` fixer to include `property` in the `elements` option ([#817]), by [@localheinz]
 
 ## [`5.10.0`][5.10.0]
 
@@ -1042,6 +1043,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#810]: https://github.com/ergebnis/php-cs-fixer-config/pull/810
 [#815]: https://github.com/ergebnis/php-cs-fixer-config/pull/815
 [#816]: https://github.com/ergebnis/php-cs-fixer-config/pull/816
+[#817]: https://github.com/ergebnis/php-cs-fixer-config/pull/817
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -792,6 +792,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -801,6 +801,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -803,6 +803,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -803,6 +803,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -797,6 +797,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -806,6 +806,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -808,6 +808,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -808,6 +808,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
         'type_declaration_spaces' => [
             'elements' => [
                 'function',
+                'property',
             ],
         ],
         'types_spaces' => [


### PR DESCRIPTION
This pull request

- [x] configures the `type_declaration_spaces` fixer to include `property` in the `elements` option

Follows #815.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.21.1/doc/rules/whitespace/type_declaration_spaces.rst.