### PR TITLE
Enhancement: Enable `php_unit_data_provider_return_type` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`5.11.1...main`][5.11.1...main].
 ## Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#825]), by [@dependabot]
+- Enabled the `php_unit_data_provider_return_type` fixer ([#826]), by [@localheinz]
 
 ## [`5.11.1`][5.11.1]
 
@@ -1067,6 +1068,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#817]: https://github.com/ergebnis/php-cs-fixer-config/pull/817
 [#824]: https://github.com/ergebnis/php-cs-fixer-config/pull/824
 [#825]: https://github.com/ergebnis/php-cs-fixer-config/pull/825
+[#826]: https://github.com/ergebnis/php-cs-fixer-config/pull/826
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -449,7 +449,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -449,7 +449,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -449,7 +449,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -449,7 +449,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -452,7 +452,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -453,7 +453,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -453,7 +453,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -454,7 +454,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -454,7 +454,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -454,7 +454,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -454,7 +454,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -457,7 +457,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -458,7 +458,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -458,7 +458,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
         ],
         'php_unit_data_provider_name' => false,
-        'php_unit_data_provider_return_type' => false,
+        'php_unit_data_provider_return_type' => true,
         'php_unit_data_provider_static' => [
             'force' => false,
         ],


### PR DESCRIPTION
This pull request

- [x] enables the `php_unit_data_provider_return_type` fixer


Follows #825.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.22.0/doc/rules/php_unit/php_unit_data_provider_return_type.rst
