### PR TITLE
Enhancement: Enable `return_to_yield_from` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`5.12.0...main`][5.12.0...main].
 ## Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#840]), by [@dependabot]
+- Enabled the `return_to_yield_from` fixer ([#841]), by [@localheinz]
 
 ## [`5.12.0`][5.12.0]
 
@@ -1080,6 +1081,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#825]: https://github.com/ergebnis/php-cs-fixer-config/pull/825
 [#826]: https://github.com/ergebnis/php-cs-fixer-config/pull/826
 [#840]: https://github.com/ergebnis/php-cs-fixer-config/pull/840
+[#841]: https://github.com/ergebnis/php-cs-fixer-config/pull/841
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -662,7 +662,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -662,7 +662,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -662,7 +662,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -664,7 +664,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -667,7 +667,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -668,7 +668,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -668,7 +668,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -667,7 +667,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -667,7 +667,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -667,7 +667,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -669,7 +669,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -672,7 +672,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -673,7 +673,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -673,7 +673,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
         ],
         'regular_callable_call' => true,
         'return_assignment' => true,
-        'return_to_yield_from' => false,
+        'return_to_yield_from' => true,
         'return_type_declaration' => [
             'space_before' => 'none',
         ],


### PR DESCRIPTION
This pull request

- [x] enables the `return_to_yield_from` fixer

Follows #840.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.23.0/doc/rules/array_notation/return_to_yield_from.rst.