### PR TITLE
Enhancement: Assert that fixers are registered, not necessarily built-in

### DIFF
--- a/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
+++ b/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
@@ -48,15 +48,15 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
     {
         $rules = self::createRuleSet()->rules();
 
-        $fixersThatAreBuiltInAndNotDeprecated = \array_filter(self::fixersThatAreBuiltIn(), static function (Fixer\FixerInterface $fixer): bool {
+        $fixersThatAreRegisteredAndNotDeprecated = \array_filter(self::fixersThatAreRegistered(), static function (Fixer\FixerInterface $fixer): bool {
             return !$fixer instanceof Fixer\DeprecatedFixerInterface;
         });
 
         $rulesThatAreNotDeprecated = \array_combine(
-            \array_keys($fixersThatAreBuiltInAndNotDeprecated),
+            \array_keys($fixersThatAreRegisteredAndNotDeprecated),
             \array_fill(
                 0,
-                \count($fixersThatAreBuiltInAndNotDeprecated),
+                \count($fixersThatAreRegisteredAndNotDeprecated),
                 false,
             ),
         );
@@ -78,16 +78,16 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
 
         $namesOfRules = \array_keys($rules);
 
-        $fixersThatAreBuiltIn = self::fixersThatAreBuiltIn();
+        $fixersThatAreRegistered = self::fixersThatAreRegistered();
 
         $rulesWithAllNonDeprecatedConfigurationOptions = \array_combine(
             $namesOfRules,
-            \array_map(static function (string $nameOfRule, $ruleConfiguration) use ($fixersThatAreBuiltIn) {
+            \array_map(static function (string $nameOfRule, $ruleConfiguration) use ($fixersThatAreRegistered) {
                 if (false === $ruleConfiguration) {
                     return false;
                 }
 
-                $fixer = $fixersThatAreBuiltIn[$nameOfRule];
+                $fixer = $fixersThatAreRegistered[$nameOfRule];
 
                 if ($fixer instanceof Fixer\DeprecatedFixerInterface) {
                     return $ruleConfiguration;

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php53::class)]
+#[Framework\Attributes\RequiresPhp('>=5.3')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php53Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 5.3)';

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php54::class)]
+#[Framework\Attributes\RequiresPhp('>=5.4')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php54Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 5.4)';

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php55::class)]
+#[Framework\Attributes\RequiresPhp('>=5.5')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php55Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 5.5)';

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php56::class)]
+#[Framework\Attributes\RequiresPhp('>=5.6')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php56Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 5.6)';

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php70::class)]
+#[Framework\Attributes\RequiresPhp('>=7.0')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php70Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 7.0)';

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php71::class)]
+#[Framework\Attributes\RequiresPhp('>=7.1')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php71Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 7.1)';

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php72::class)]
+#[Framework\Attributes\RequiresPhp('>=7.2')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php72Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 7.2)';

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php73::class)]
+#[Framework\Attributes\RequiresPhp('>=7.3')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php73Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 7.3)';

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php74::class)]
+#[Framework\Attributes\RequiresPhp('>=7.4')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php74Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 7.4)';

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php80::class)]
+#[Framework\Attributes\RequiresPhp('>=8.0')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php80Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 8.0)';

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php81::class)]
+#[Framework\Attributes\RequiresPhp('>=8.1')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php81Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 8.1)';

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\AbstractRuleSet::class)]
 #[Framework\Attributes\CoversClass(RuleSet\Php82::class)]
+#[Framework\Attributes\RequiresPhp('>=8.2')]
+#[Framework\Attributes\UsesClass(Factory::class)]
 final class Php82Test extends ExplicitRuleSetTestCase
 {
     protected string $name = 'ergebnis (PHP 8.2)';


### PR DESCRIPTION
This pull request

- [x] asserts that fixers are registered, not necessarily built-in