### PR TITLE
Fix: Target PHP versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`5.15.1...main`][5.15.1...main].
 
+### Fixed
+
+- Fixed target PHP versions in `Config\Ruleset\Php53`, `Config\Ruleset\Php54`, `Config\Ruleset\Php55`, `Config\Ruleset\Php56`, and `Config\Ruleset\Php70` ([#864]), by [@localheinz]
+
 ## [`5.15.1`][5.15.1]
 
 For a full diff see [`5.15.0...5.15.1`][5.15.0...5.15.1].
@@ -1143,6 +1147,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#850]: https://github.com/ergebnis/php-cs-fixer-config/pull/850
 [#856]: https://github.com/ergebnis/php-cs-fixer-config/pull/856
 [#857]: https://github.com/ergebnis/php-cs-fixer-config/pull/857
+[#864]: https://github.com/ergebnis/php-cs-fixer-config/pull/864
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -810,5 +810,5 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50300;
 }

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -812,5 +812,5 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50400;
 }

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -821,5 +821,5 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50500;
 }

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -821,5 +821,5 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50600;
 }

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -821,5 +821,5 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 70000;
 }

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -815,5 +815,5 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50300;
 }

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -817,5 +817,5 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50400;
 }

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -826,5 +826,5 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50500;
 }

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -826,5 +826,5 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 50600;
 }

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -826,5 +826,5 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+    protected int $targetPhpVersion = 70000;
 }


### PR DESCRIPTION
This pull request

- [x] fixes target PHP versions in `Config\Ruleset\Php53`, `Config\Ruleset\Php54`, `Config\Ruleset\Php55`, `Config\Ruleset\Php56`, and `Config\Ruleset\Php70`