### PR TITLE
Fix: Remove `$targetPhpVersion` field and `targetPhpVersion()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 ### Removed
 
 - Removed `$name` field from `Config\Ruleset\AbstractRuleSet` ([#865]), by [@localheinz]
+- Removed `$targetPhpVersion` field and `targetPhpVersion()` method from `Config\Ruleset\AbstractRuleSet` ([#866]), by [@localheinz]
 
 ## [`5.15.1`][5.15.1]
 
@@ -1152,6 +1153,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#856]: https://github.com/ergebnis/php-cs-fixer-config/pull/856
 [#857]: https://github.com/ergebnis/php-cs-fixer-config/pull/857
 [#864]: https://github.com/ergebnis/php-cs-fixer-config/pull/864
+[#866]: https://github.com/ergebnis/php-cs-fixer-config/pull/866
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/infection.json
+++ b/infection.json
@@ -3,8 +3,8 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 85,
-  "minMsi": 85,
+  "minCoveredMsi": 94,
+  "minMsi": 89,
   "phpUnit": {
     "configDir": "test\/Unit"
   },

--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -121,7 +121,6 @@ abstract class AbstractRuleSet implements RuleSet
      * @var array<string, array<string, mixed>|bool>
      */
     protected array $rules = [];
-    protected int $targetPhpVersion = 0;
 
     final public function __construct(?string $header = null)
     {
@@ -139,13 +138,15 @@ abstract class AbstractRuleSet implements RuleSet
 
     final public function name(): string
     {
+        $targetPhpVersion = $this->targetPhpVersion();
+
         $major = \intdiv(
-            $this->targetPhpVersion,
+            $targetPhpVersion,
             10_000,
         );
 
         $minor = \intdiv(
-            $this->targetPhpVersion % 10_000,
+            $targetPhpVersion % 10_000,
             100,
         );
 
@@ -159,10 +160,5 @@ abstract class AbstractRuleSet implements RuleSet
     final public function rules(): array
     {
         return $this->rules;
-    }
-
-    final public function targetPhpVersion(): int
-    {
-        return $this->targetPhpVersion;
     }
 }

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -809,5 +809,9 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 50300;
+
+    public function targetPhpVersion(): int
+    {
+        return 50300;
+    }
 }

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -811,5 +811,9 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 50400;
+
+    public function targetPhpVersion(): int
+    {
+        return 50400;
+    }
 }

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -820,5 +820,9 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 50500;
+
+    public function targetPhpVersion(): int
+    {
+        return 50500;
+    }
 }

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -820,5 +820,9 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 50600;
+
+    public function targetPhpVersion(): int
+    {
+        return 50600;
+    }
 }

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -820,5 +820,9 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70000;
+
+    public function targetPhpVersion(): int
+    {
+        return 70000;
+    }
 }

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -823,5 +823,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70100;
+
+    public function targetPhpVersion(): int
+    {
+        return 70100;
+    }
 }

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -823,5 +823,9 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70200;
+
+    public function targetPhpVersion(): int
+    {
+        return 70200;
+    }
 }

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -824,5 +824,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70300;
+
+    public function targetPhpVersion(): int
+    {
+        return 70300;
+    }
 }

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -827,5 +827,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 70400;
+
+    public function targetPhpVersion(): int
+    {
+        return 70400;
+    }
 }

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -836,5 +836,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 80000;
+
+    public function targetPhpVersion(): int
+    {
+        return 80000;
+    }
 }

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -838,5 +838,9 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 80100;
+
+    public function targetPhpVersion(): int
+    {
+        return 80100;
+    }
 }

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -838,5 +838,9 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'less_and_greater' => true,
         ],
     ];
-    protected int $targetPhpVersion = 80200;
+
+    public function targetPhpVersion(): int
+    {
+        return 80200;
+    }
 }


### PR DESCRIPTION
This pull request

- [x] removes the `$targetPhpVersion` field and `targetPhpVersion()` method from `AbstractRuleSet`
