### PR TITLE
Fix: Remove `name()` method from `AbstractRuleSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 
 - Removed `$name` field from `Config\Ruleset\AbstractRuleSet` ([#865]), by [@localheinz]
 - Removed `$targetPhpVersion` field and `targetPhpVersion()` method from `Config\Ruleset\AbstractRuleSet` ([#866]), by [@localheinz]
+- Removed `name()` method from `Config\Ruleset\AbstractRuleSet` ([#867]), by [@localheinz]
 
 ## [`5.15.1`][5.15.1]
 
@@ -1154,6 +1155,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#857]: https://github.com/ergebnis/php-cs-fixer-config/pull/857
 [#864]: https://github.com/ergebnis/php-cs-fixer-config/pull/864
 [#866]: https://github.com/ergebnis/php-cs-fixer-config/pull/866
+[#867]: https://github.com/ergebnis/php-cs-fixer-config/pull/867
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/infection.json
+++ b/infection.json
@@ -3,8 +3,8 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 94,
-  "minMsi": 89,
+  "minCoveredMsi": 100,
+  "minMsi": 93,
   "phpUnit": {
     "configDir": "test\/Unit"
   },

--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -136,27 +136,6 @@ abstract class AbstractRuleSet implements RuleSet
         ];
     }
 
-    final public function name(): string
-    {
-        $targetPhpVersion = $this->targetPhpVersion();
-
-        $major = \intdiv(
-            $targetPhpVersion,
-            10_000,
-        );
-
-        $minor = \intdiv(
-            $targetPhpVersion % 10_000,
-            100,
-        );
-
-        return \sprintf(
-            'ergebnis (PHP %d.%s)',
-            $major,
-            $minor,
-        );
-    }
-
     final public function rules(): array
     {
         return $this->rules;

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -810,6 +810,11 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 5.3)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 50300;

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -812,6 +812,11 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 5.4)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 50400;

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -821,6 +821,11 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 5.5)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 50500;

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -821,6 +821,11 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 5.6)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 50600;

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -821,6 +821,11 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 7.0)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 70000;

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -824,6 +824,11 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 7.1)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 70100;

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -824,6 +824,11 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 7.2)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 70200;

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -825,6 +825,11 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 7.3)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 70300;

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -828,6 +828,11 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 7.4)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 70400;

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -837,6 +837,11 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 8.0)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 80000;

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -839,6 +839,11 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 8.1)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 80100;

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -839,6 +839,11 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function name(): string
+    {
+        return 'ergebnis (PHP 8.2)';
+    }
+
     public function targetPhpVersion(): int
     {
         return 80200;


### PR DESCRIPTION
This pull request

- [x] removes the `name()` method from `AbstractRuleSet`