### PR TITLE
Fix: Remove `rules()` method from `AbstractRuleSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 - Removed `$name` field from `Config\Ruleset\AbstractRuleSet` ([#865]), by [@localheinz]
 - Removed `$targetPhpVersion` field and `targetPhpVersion()` method from `Config\Ruleset\AbstractRuleSet` ([#866]), by [@localheinz]
 - Removed `name()` method from `Config\Ruleset\AbstractRuleSet` ([#867]), by [@localheinz]
+- Removed `rules()` method from `Config\Ruleset\AbstractRuleSet` ([#868]), by [@localheinz]
 
 ## [`5.15.1`][5.15.1]
 
@@ -1156,6 +1157,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#864]: https://github.com/ergebnis/php-cs-fixer-config/pull/864
 [#866]: https://github.com/ergebnis/php-cs-fixer-config/pull/866
 [#867]: https://github.com/ergebnis/php-cs-fixer-config/pull/867
+[#868]: https://github.com/ergebnis/php-cs-fixer-config/pull/868
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,61 +6,109 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php53.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php54.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php55.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php56.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php70.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php71.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php72.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php73.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php74.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php80.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php81.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="src/RuleSet/Php82.php">
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->rules]]></code>
+      <code>array</code>
+    </MixedReturnTypeCoercion>
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>

--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -135,9 +135,4 @@ abstract class AbstractRuleSet implements RuleSet
             'separate' => 'both',
         ];
     }
-
-    final public function rules(): array
-    {
-        return $this->rules;
-    }
 }

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -815,6 +815,11 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 5.3)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 50300;

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -817,6 +817,11 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 5.4)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 50400;

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -826,6 +826,11 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 5.5)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 50500;

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -826,6 +826,11 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 5.6)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 50600;

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -826,6 +826,11 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 7.0)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 70000;

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -829,6 +829,11 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 7.1)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 70100;

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -829,6 +829,11 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 7.2)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 70200;

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -830,6 +830,11 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 7.3)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 70300;

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -833,6 +833,11 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 7.4)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 70400;

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -842,6 +842,11 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 8.0)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 80000;

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -844,6 +844,11 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 8.1)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 80100;

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -844,6 +844,11 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         return 'ergebnis (PHP 8.2)';
     }
 
+    public function rules(): array
+    {
+        return $this->rules;
+    }
+
     public function targetPhpVersion(): int
     {
         return 80200;


### PR DESCRIPTION
This pull request

- [x] removes the `rules()` method from `AbstractRuleSet`
