### PR TITLE
Enhancement: Allow `Config\RuleSet` to declare and configure custom fixers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 - Extracted `Config\Name` as a value object ([#870]), by [@localheinz]
 - Extracted `Config\PhpVersion` as a value object ([#871]), by [@localheinz]
 
+### Changed
+
+- Allow implementations of  `Config\RuleSet` to declare and configure custom fixers ([#872]), by [@localheinz]
+
 ### Fixed
 
 - Fixed target PHP versions in `Config\Ruleset\Php53`, `Config\Ruleset\Php54`, `Config\Ruleset\Php55`, `Config\Ruleset\Php56`, and `Config\Ruleset\Php70` ([#864]), by [@localheinz]
@@ -1165,6 +1169,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#868]: https://github.com/ergebnis/php-cs-fixer-config/pull/868
 [#870]: https://github.com/ergebnis/php-cs-fixer-config/pull/870
 [#871]: https://github.com/ergebnis/php-cs-fixer-config/pull/871
+[#872]: https://github.com/ergebnis/php-cs-fixer-config/pull/872
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -115,8 +115,10 @@
   </file>
   <file src="test/Double/Config/RuleSet/DummyRuleSet.php">
     <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->customFixers]]></code>
       <code><![CDATA[$this->rules]]></code>
       <code>array</code>
+      <code>iterable</code>
     </MixedReturnTypeCoercion>
   </file>
   <file src="test/EndToEnd/RuleSet/AbstractRuleSetTestCase.php">

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -40,6 +40,7 @@ final class Factory
 
         $config = new Config($ruleSet->name()->toString());
 
+        $config->registerCustomFixers($ruleSet->customFixers());
         $config->setRiskyAllowed(true);
         $config->setRules(\array_merge(
             $ruleSet->rules(),

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -13,8 +13,15 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config;
 
+use PhpCsFixer\Fixer;
+
 interface RuleSet
 {
+    /**
+     * @return iterable<Fixer\FixerInterface>
+     */
+    public function customFixers(): iterable;
+
     /**
      * Returns the name of the rule set.
      */

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -813,6 +813,11 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -815,6 +815,11 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -824,6 +824,11 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -824,6 +824,11 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -824,6 +824,11 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -827,6 +827,11 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -827,6 +827,11 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -828,6 +828,11 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -831,6 +831,11 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -840,6 +840,11 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -842,6 +842,11 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -842,6 +842,11 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function customFixers(): iterable
+    {
+        yield from [];
+    }
+
     public function name(): Name
     {
         return Name::fromPhpVersion($this->targetPhpVersion());

--- a/test/Double/Config/RuleSet/DummyRuleSet.php
+++ b/test/Double/Config/RuleSet/DummyRuleSet.php
@@ -20,10 +20,16 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 final class DummyRuleSet implements RuleSet
 {
     public function __construct(
+        private readonly iterable $customFixers,
         private readonly Name $name,
         private readonly array $rules,
         private readonly PhpVersion $phpVersion,
     ) {
+    }
+
+    public function customFixers(): iterable
+    {
+        return $this->customFixers;
     }
 
     public function name(): Name

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -17,6 +17,7 @@ use Ergebnis\PhpCsFixer\Config\Factory;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Test;
+use PhpCsFixer\Fixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(Factory::class)]
@@ -38,6 +39,7 @@ final class FactoryTest extends Framework\TestCase
         );
 
         $ruleSet = new Test\Double\Config\RuleSet\DummyRuleSet(
+            [],
             Name::fromString(self::faker()->word()),
             [],
             $targetPhpVersion,
@@ -56,6 +58,12 @@ final class FactoryTest extends Framework\TestCase
     #[Framework\Attributes\DataProvider('provideTargetPhpVersionLessThanOrEqualToCurrentPhpVersion')]
     public function testFromRuleSetCreatesConfigWhenCurrentPhpVersionIsEqualToOrGreaterThanTargetPhpVersion(PhpVersion $targetPhpVersion): void
     {
+        $customFixers = [
+            $this->createStub(Fixer\FixerInterface::class),
+            $this->createStub(Fixer\FixerInterface::class),
+            $this->createStub(Fixer\FixerInterface::class),
+        ];
+
         $rules = [
             'foo' => true,
             'bar' => [
@@ -64,6 +72,7 @@ final class FactoryTest extends Framework\TestCase
         ];
 
         $ruleSet = new Test\Double\Config\RuleSet\DummyRuleSet(
+            $customFixers,
             Name::fromString(self::faker()->word()),
             $rules,
             $targetPhpVersion,
@@ -71,6 +80,7 @@ final class FactoryTest extends Framework\TestCase
 
         $config = Factory::fromRuleSet($ruleSet);
 
+        self::assertEquals($customFixers, $config->getCustomFixers());
         self::assertTrue($config->getRiskyAllowed());
         self::assertSame($rules, $config->getRules());
         self::assertTrue($config->getUsingCache());
@@ -95,6 +105,12 @@ final class FactoryTest extends Framework\TestCase
 
     public function testFromRuleSetCreatesConfigWithOverrideRules(): void
     {
+        $customFixers = [
+            $this->createStub(Fixer\FixerInterface::class),
+            $this->createStub(Fixer\FixerInterface::class),
+            $this->createStub(Fixer\FixerInterface::class),
+        ];
+
         $rules = [
             'foo' => true,
             'bar' => [
@@ -103,6 +119,7 @@ final class FactoryTest extends Framework\TestCase
         ];
 
         $ruleSet = new Test\Double\Config\RuleSet\DummyRuleSet(
+            $customFixers,
             Name::fromString(self::faker()->word()),
             $rules,
             PhpVersion::create(
@@ -121,6 +138,7 @@ final class FactoryTest extends Framework\TestCase
             $overrideRules,
         );
 
+        self::assertEquals($customFixers, $config->getCustomFixers());
         self::assertTrue($config->getRiskyAllowed());
         self::assertEquals(\array_merge($rules, $overrideRules), $config->getRules());
         self::assertTrue($config->getUsingCache());

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -128,6 +128,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     {
         $ruleSet = self::createRuleSet();
 
+        self::assertEquals($this->expectedCustomFixers(), $ruleSet->customFixers());
         self::assertEquals($this->expectedName(), $ruleSet->name());
         self::assertEquals($this->expectedRules(), $ruleSet->rules());
         self::assertEquals($this->expectedTargetPhpVersion(), $ruleSet->targetPhpVersion());
@@ -306,6 +307,8 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
             ];
         }
     }
+
+    abstract protected function expectedCustomFixers(): iterable;
 
     abstract protected function expectedName(): Name;
 

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php53Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 5.3)');

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php54Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 5.4)');

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php55Test extends ExplicitRuleSetTestCase
 {
+    public function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 5.5)');

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php56Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 5.6)');

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php70Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 7.0)');

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php71Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 7.1)');

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php72Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 7.2)');

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php73Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 7.3)');

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php74Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 7.4)');

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php80Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 8.0)');

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php81Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 8.1)');

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -30,6 +30,11 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(PhpVersion\Patch::class)]
 final class Php82Test extends ExplicitRuleSetTestCase
 {
+    protected function expectedCustomFixers(): iterable
+    {
+        yield from [];
+    }
+
     protected function expectedName(): Name
     {
         return Name::fromString('ergebnis (PHP 8.2)');


### PR DESCRIPTION
This pull request

- [x] allows implementations of `Config\RuleSet` to declare and configure custom fixers