### PR TITLE
Fix: Remove constructor from `RuleSet\AbstractRuleSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 - Removed `name()` method from `Config\Ruleset\AbstractRuleSet` ([#867]), by [@localheinz]
 - Removed `rules()` method from `Config\Ruleset\AbstractRuleSet` ([#868]), by [@localheinz]
 - Removed `DOCTRINE_IGNORED_TAGS` constant from `Config\Ruleset\AbstractRuleSet` ([#875]), by [@localheinz]
+- Removed constructor from `Config\Ruleset\AbstractRuleSet` ([#876]), by [@localheinz]
 
 ## [`5.15.1`][5.15.1]
 
@@ -1174,6 +1175,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#872]: https://github.com/ergebnis/php-cs-fixer-config/pull/872
 [#874]: https://github.com/ergebnis/php-cs-fixer-config/pull/874
 [#875]: https://github.com/ergebnis/php-cs-fixer-config/pull/875
+[#876]: https://github.com/ergebnis/php-cs-fixer-config/pull/876
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/RuleSet/AbstractRuleSet.php">
-    <PossiblyUnusedMethod>
-      <code>__construct</code>
-    </PossiblyUnusedMethod>
+    <PossiblyUnusedProperty>
+      <code>$rules</code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/RuleSet/Php53.php">
     <MixedArgumentTypeCoercion>
@@ -12,6 +12,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php54.php">
     <MixedArgumentTypeCoercion>
@@ -20,6 +23,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php55.php">
     <MixedArgumentTypeCoercion>
@@ -28,6 +34,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php56.php">
     <MixedArgumentTypeCoercion>
@@ -36,6 +45,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php70.php">
     <MixedArgumentTypeCoercion>
@@ -44,6 +56,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php71.php">
     <MixedArgumentTypeCoercion>
@@ -52,6 +67,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php72.php">
     <MixedArgumentTypeCoercion>
@@ -60,6 +78,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php73.php">
     <MixedArgumentTypeCoercion>
@@ -68,6 +89,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php74.php">
     <MixedArgumentTypeCoercion>
@@ -76,6 +100,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php80.php">
     <MixedArgumentTypeCoercion>
@@ -84,6 +111,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php81.php">
     <MixedArgumentTypeCoercion>
@@ -92,6 +122,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/RuleSet/Php82.php">
     <MixedArgumentTypeCoercion>
@@ -100,6 +133,9 @@
     <NonInvariantDocblockPropertyType>
       <code>$rules</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Rules.php">
     <MixedArgumentTypeCoercion>

--- a/src/RuleSet/AbstractRuleSet.php
+++ b/src/RuleSet/AbstractRuleSet.php
@@ -21,18 +21,4 @@ abstract class AbstractRuleSet implements RuleSet
      * @var array<string, array<string, mixed>|bool>
      */
     protected array $rules = [];
-
-    final public function __construct(?string $header = null)
-    {
-        if (null === $header) {
-            return;
-        }
-
-        $this->rules['header_comment'] = [
-            'comment_type' => 'PHPDoc',
-            'header' => \trim($header),
-            'location' => 'after_declare_strict',
-            'separate' => 'both',
-        ];
-    }
 }

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -814,6 +814,20 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -816,6 +816,20 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -825,6 +825,20 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -825,6 +825,20 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -825,6 +825,20 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -828,6 +828,20 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -828,6 +828,20 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -829,6 +829,20 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -832,6 +832,20 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -841,6 +841,20 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -843,6 +843,20 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -843,6 +843,20 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
         ],
     ];
 
+    public function __construct(?string $header = null)
+    {
+        if (null === $header) {
+            return;
+        }
+
+        $this->rules['header_comment'] = [
+            'comment_type' => 'PHPDoc',
+            'header' => \trim($header),
+            'location' => 'after_declare_strict',
+            'separate' => 'both',
+        ];
+    }
+
     public function customFixers(): iterable
     {
         yield from [];


### PR DESCRIPTION
This pull request

- [x] removes the constructor from `RuleSet\AbstractRuleSet`
