### PR TITLE
Fix: Rename `Config\RuleSet::targetPhpVersion()` to `Config\RuleSet::phpVersion()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 ### Changed
 
 - Allow implementations of `Config\RuleSet` to declare and configure custom fixers ([#872]), by [@localheinz]
+- Renamed `Config\RuleSet::targetPhpVersion()` to `Config\RuleSet::phpVersion()` ([#878]), by [@localheinz]
 
 ### Fixed
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,11 +28,11 @@ final class Factory
     ): Config {
         $currentPhpVersion = PhpVersion::current();
 
-        if ($currentPhpVersion->isSmallerThan($ruleSet->targetPhpVersion())) {
+        if ($currentPhpVersion->isSmallerThan($ruleSet->phpVersion())) {
             throw new \RuntimeException(\sprintf(
                 'Current PHP version "%s" is smaller than targeted PHP version "%s".',
                 $currentPhpVersion->toString(),
-                $ruleSet->targetPhpVersion()->toString(),
+                $ruleSet->phpVersion()->toString(),
             ));
         }
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -35,5 +35,5 @@ interface RuleSet
     /**
      * Returns the minimum required PHP version.
      */
-    public function targetPhpVersion(): PhpVersion;
+    public function phpVersion(): PhpVersion;
 }

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -858,7 +858,7 @@ final class Php53 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -860,7 +860,7 @@ final class Php54 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -869,7 +869,7 @@ final class Php55 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -869,7 +869,7 @@ final class Php56 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -870,7 +870,7 @@ final class Php70 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -872,7 +872,7 @@ final class Php71 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -872,7 +872,7 @@ final class Php72 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -873,7 +873,7 @@ final class Php73 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -876,7 +876,7 @@ final class Php74 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -885,7 +885,7 @@ final class Php80 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -887,7 +887,7 @@ final class Php81 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -887,7 +887,7 @@ final class Php82 implements ExplicitRuleSet, RuleSet
         return Rules::fromArray($this->rules);
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->targetPhpVersion;
     }

--- a/test/Double/Config/RuleSet/DummyRuleSet.php
+++ b/test/Double/Config/RuleSet/DummyRuleSet.php
@@ -43,7 +43,7 @@ final class DummyRuleSet implements RuleSet
         return $this->rules;
     }
 
-    public function targetPhpVersion(): PhpVersion
+    public function phpVersion(): PhpVersion
     {
         return $this->phpVersion;
     }

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -31,7 +31,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         self::assertEquals($this->expectedCustomFixers(), $ruleSet->customFixers());
         self::assertEquals($this->expectedName(), $ruleSet->name());
         self::assertEquals($this->expectedRules(), $ruleSet->rules());
-        self::assertEquals($this->expectedTargetPhpVersion(), $ruleSet->targetPhpVersion());
+        self::assertEquals($this->expectedPhpVersion(), $ruleSet->phpVersion());
     }
 
     final public function testRuleSetDoesNotConfigureRulesThatAreNotRegistered(): void
@@ -222,7 +222,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
     abstract protected function expectedRules(): Rules;
 
-    abstract protected function expectedTargetPhpVersion(): PhpVersion;
+    abstract protected function expectedPhpVersion(): PhpVersion;
 
     /**
      * @throws \RuntimeException

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -843,7 +843,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(5),

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -845,7 +845,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(5),

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -854,7 +854,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(5),

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -854,7 +854,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(5),

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -854,7 +854,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(7),

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -857,7 +857,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(7),

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -857,7 +857,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(7),

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -858,7 +858,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(7),

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -861,7 +861,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(7),

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -870,7 +870,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(8),

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -872,7 +872,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(8),

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -872,7 +872,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
         ]);
     }
 
-    protected function expectedTargetPhpVersion(): PhpVersion
+    protected function expectedPhpVersion(): PhpVersion
     {
         return PhpVersion::create(
             PhpVersion\Major::fromInt(8),


### PR DESCRIPTION
This pull request

- [x] renames `Config\RuleSet::targetPhpVersion()` to `Config\RuleSet::phpVersion()`
