### PR TITLE
Enhancement: Enable `long_to_shorthand_operator` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`5.15.1...main`][5.15.1...main].
 ## Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#880]), by [@dependabot]
+- Enabled `long_to_shorthand_operator` fixer ([#881]), by [@localheinz]
 
 ## [`5.15.1`][5.15.1]
 
@@ -1148,6 +1149,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#856]: https://github.com/ergebnis/php-cs-fixer-config/pull/856
 [#857]: https://github.com/ergebnis/php-cs-fixer-config/pull/857
 [#880]: https://github.com/ergebnis/php-cs-fixer-config/pull/880
+[#881]: https://github.com/ergebnis/php-cs-fixer-config/pull/881
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -231,7 +231,7 @@ final class Php53 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -232,7 +232,7 @@ final class Php54 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -234,7 +234,7 @@ final class Php55 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -234,7 +234,7 @@ final class Php56 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -234,7 +234,7 @@ final class Php70 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'long',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -234,7 +234,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -234,7 +234,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -234,7 +234,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -234,7 +234,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -234,7 +234,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -234,7 +234,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -234,7 +234,7 @@ final class Php82 extends AbstractRuleSet implements ExplicitRuleSet
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -236,7 +236,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -237,7 +237,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -239,7 +239,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -239,7 +239,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -239,7 +239,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'syntax' => 'long',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -239,7 +239,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -239,7 +239,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -239,7 +239,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -239,7 +239,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -239,7 +239,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -239,7 +239,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -239,7 +239,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'syntax' => 'short',
         ],
         'logical_operators' => true,
-        'long_to_shorthand_operator' => false,
+        'long_to_shorthand_operator' => true,
         'lowercase_cast' => true,
         'lowercase_keywords' => true,
         'lowercase_static_reference' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `long_to_shorthand_operator` fixer

Follows #880.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.27.0/doc/rules/operator/long_to_shorthand_operator.rst.