### PR TITLE
Fix: Rename `Config\RuleSet\ExplicitRuleSet` to `Config\ExplicitRuleSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`5.16.0...main`][5.16.0...main].
 
 - Allow implementations of `Config\RuleSet` to declare and configure custom fixers ([#872]), by [@localheinz]
 - Renamed `Config\RuleSet::targetPhpVersion()` to `Config\RuleSet::phpVersion()` ([#878]), by [@localheinz]
+- Renamed `Config\RuleSet\ExplicitRuleSet` to `Config\ExplicitRuleSet` ([#882]), by [@localheinz]
 
 ### Fixed
 
@@ -1192,6 +1193,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#877]: https://github.com/ergebnis/php-cs-fixer-config/pull/877
 [#880]: https://github.com/ergebnis/php-cs-fixer-config/pull/880
 [#881]: https://github.com/ergebnis/php-cs-fixer-config/pull/881
+[#882]: https://github.com/ergebnis/php-cs-fixer-config/pull/882
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/ExplicitRuleSet.php
+++ b/src/ExplicitRuleSet.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/php-cs-fixer-config
  */
 
-namespace Ergebnis\PhpCsFixer\Config\RuleSet;
+namespace Ergebnis\PhpCsFixer\Config;
 
 /**
  * Marker interface for explicit rule sets.

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\RuleSet;
 
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;

--- a/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
+++ b/test/Unit/RuleSet/ExplicitRuleSetTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
-use Ergebnis\PhpCsFixer\Config\RuleSet;
+use Ergebnis\PhpCsFixer\Config\ExplicitRuleSet;
 use PhpCsFixer\Fixer;
 use PhpCsFixer\FixerConfiguration;
 
@@ -23,7 +23,7 @@ abstract class ExplicitRuleSetTestCase extends AbstractRuleSetTestCase
     {
         $ruleSet = static::createRuleSet();
 
-        self::assertInstanceOf(RuleSet\ExplicitRuleSet::class, $ruleSet);
+        self::assertInstanceOf(ExplicitRuleSet::class, $ruleSet);
     }
 
     final public function testRuleSetDoesNotConfigureRuleSets(): void


### PR DESCRIPTION
This pull request

- [x] renames `Config\RuleSet\ExplicitRuleSet` to `Config\ExplicitRuleSet`