### PR TITLE
Enhancement: Remove optional parameter and introduce `withHeader()` mutator

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = PhpCsFixer\Config\Factory::fromRuleSet(PhpCsFixer\Config\RuleSet\Php81::create($license->header()));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(PhpCsFixer\Config\RuleSet\Php81::create()->withHeader($license->header()));
 
 $config->getFinder()
     ->exclude([

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For a full diff see [`5.16.0...main`][5.16.0...main].
 
 - Allow implementations of `Config\RuleSet` to declare and configure custom fixers ([#872]), by [@localheinz]
 - Renamed `Config\RuleSet::targetPhpVersion()` to `Config\RuleSet::phpVersion()` ([#878]), by [@localheinz]
-- Reduced visibility of constructors and extracted named constructors `Config\RuleSet\Php53::create()`, `Config\RuleSet\Php54::create()`, `Config\RuleSet\Php55::create()`, `Config\RuleSet\Php56::create()`, `Config\RuleSet\Php70::create()`, `Config\RuleSet\Php71::create()`, `Config\RuleSet\Php72::create()`, `Config\RuleSet\Php73::create()`, `Config\RuleSet\Php74::create()`, `Config\RuleSet\Php80::create()`,  `Config\RuleSet\Php81::create()`,  `Config\RuleSet\Php82::create()` ([#886]), by [@localheinz]
+- Reduced visibility of constructors and extracted named constructors `Config\RuleSet\Php53::withHeader()`, `Config\RuleSet\Php54::withHeader()`, `Config\RuleSet\Php55::withHeader()`, `Config\RuleSet\Php56::withHeader()`, `Config\RuleSet\Php70::withHeader()`, `Config\RuleSet\Php71::withHeader()`, `Config\RuleSet\Php72::withHeader()`, `Config\RuleSet\Php73::withHeader()`, `Config\RuleSet\Php74::withHeader()`, `Config\RuleSet\Php80::withHeader()`,  `Config\RuleSet\Php81::withHeader()`,  `Config\RuleSet\Php82::withHeader()` ([#886]), by [@localheinz]
 
 ### Fixed
 
@@ -35,6 +35,7 @@ For a full diff see [`5.16.0...main`][5.16.0...main].
 - Removed constructor from `Config\Ruleset\AbstractRuleSet` ([#876]), by [@localheinz]
 - Removed `Config\Ruleset\AbstractRuleSet` ([#877]), by [@localheinz]
 - Removed `Config\RuleSet\ExplicitRuleSet` ([#885]), by [@localheinz]
+- Removed optional `$header` parameter from `Config\RuleSet\Php53::withHeader()`, `Config\RuleSet\Php54::withHeader()`, `Config\RuleSet\Php55::withHeader()`, `Config\RuleSet\Php56::withHeader()`, `Config\RuleSet\Php70::withHeader()`, `Config\RuleSet\Php71::withHeader()`, `Config\RuleSet\Php72::withHeader()`, `Config\RuleSet\Php73::withHeader()`, `Config\RuleSet\Php74::withHeader()`, `Config\RuleSet\Php80::withHeader()`,  `Config\RuleSet\Php81::withHeader()`,  `Config\RuleSet\Php82::withHeader()` and added `Config\RuleSet\Php53::withHeader()`, `Config\RuleSet\Php54::withHeader()`, `Config\RuleSet\Php55::withHeader()`, `Config\RuleSet\Php56::withHeader()`, `Config\RuleSet\Php70::withHeader()`, `Config\RuleSet\Php71::withHeader()`, `Config\RuleSet\Php72::withHeader()`, `Config\RuleSet\Php73::withHeader()`, `Config\RuleSet\Php74::withHeader()`, `Config\RuleSet\Php80::withHeader()`,  `Config\RuleSet\Php81::withHeader()`,  `Config\RuleSet\Php82::withHeader()` mutators ([#887]), by [@localheinz]
 
 ## [`5.16.0`][5.16.0]
 
@@ -1198,6 +1199,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#883]: https://github.com/ergebnis/php-cs-fixer-config/pull/883
 [#885]: https://github.com/ergebnis/php-cs-fixer-config/pull/885
 [#886]: https://github.com/ergebnis/php-cs-fixer-config/pull/886
+[#887]: https://github.com/ergebnis/php-cs-fixer-config/pull/887
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All configuration examples use the caching feature, and if you want to use it as
 +EOF;
 
 -$config = Config\Factory::fromRuleSet(Config\RuleSet\Php82::create());
-+$config = Config\Factory::fromRuleSet(Config\RuleSet\Php82::create($header));
++$config = Config\Factory::fromRuleSet(Config\RuleSet\Php82::create()->withHeader($header)));
 
  $config->getFinder()->in(__DIR__);
  $config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php-cs-fixer.cache');

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -34,4 +34,11 @@ interface RuleSet
      * Returns rules along with their configuration.
      */
     public function rules(): Rules;
+
+    /**
+     * Returns rules along with the header_comment fixer enabled to add a header.
+     *
+     * @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.27.0/doc/rules/comment/header_comment.rst
+     */
+    public function withHeader(string $header): self;
 }

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -38,7 +38,7 @@ final class Php53 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -847,17 +847,6 @@ final class Php53 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -884,5 +873,22 @@ final class Php53 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -38,7 +38,7 @@ final class Php54 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -849,17 +849,6 @@ final class Php54 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -886,5 +875,22 @@ final class Php54 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -38,7 +38,7 @@ final class Php55 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -858,17 +858,6 @@ final class Php55 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -895,5 +884,22 @@ final class Php55 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -38,7 +38,7 @@ final class Php56 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -858,17 +858,6 @@ final class Php56 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -895,5 +884,22 @@ final class Php56 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -38,7 +38,7 @@ final class Php70 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -858,17 +858,6 @@ final class Php70 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -895,5 +884,22 @@ final class Php70 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -38,7 +38,7 @@ final class Php71 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -861,17 +861,6 @@ final class Php71 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -898,5 +887,22 @@ final class Php71 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -38,7 +38,7 @@ final class Php72 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -861,17 +861,6 @@ final class Php72 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -898,5 +887,22 @@ final class Php72 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -38,7 +38,7 @@ final class Php73 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -862,17 +862,6 @@ final class Php73 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -899,5 +888,22 @@ final class Php73 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -38,7 +38,7 @@ final class Php74 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -865,17 +865,6 @@ final class Php74 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -902,5 +891,22 @@ final class Php74 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -38,7 +38,7 @@ final class Php80 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -874,17 +874,6 @@ final class Php80 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -911,5 +900,22 @@ final class Php80 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -38,7 +38,7 @@ final class Php81 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -876,17 +876,6 @@ final class Php81 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -913,5 +902,22 @@ final class Php81 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -38,7 +38,7 @@ final class Php82 implements RuleSet
         $this->rules = $rules;
     }
 
-    public static function create(?string $header = null): self
+    public static function create(): self
     {
         $fixers = Fixers::empty();
         $phpVersion = PhpVersion::create(
@@ -876,17 +876,6 @@ final class Php82 implements RuleSet
             ],
         ]);
 
-        if (\is_string($header)) {
-            $rules = $rules->merge(Rules::fromArray([
-                'header_comment' => [
-                    'comment_type' => 'PHPDoc',
-                    'header' => \trim($header),
-                    'location' => 'after_declare_strict',
-                    'separate' => 'both',
-                ],
-            ]));
-        }
-
         return new self(
             $fixers,
             $name,
@@ -913,5 +902,22 @@ final class Php82 implements RuleSet
     public function rules(): Rules
     {
         return $this->rules;
+    }
+
+    public function withHeader(string $header): RuleSet
+    {
+        return new self(
+            $this->customFixers,
+            $this->name,
+            $this->phpVersion,
+            $this->rules->merge(Rules::fromArray([
+                'header_comment' => [
+                    'comment_type' => 'PHPDoc',
+                    'header' => \trim($header),
+                    'location' => 'after_declare_strict',
+                    'separate' => 'both',
+                ],
+            ])),
+        );
     }
 }

--- a/test/Double/Config/RuleSet/DummyRuleSet.php
+++ b/test/Double/Config/RuleSet/DummyRuleSet.php
@@ -48,4 +48,12 @@ final class DummyRuleSet implements RuleSet
     {
         return $this->rules;
     }
+
+    public function withHeader(string $header): RuleSet
+    {
+        throw new \BadMethodCallException(\sprintf(
+            'Method "%s" is not implemented yet.',
+            __METHOD__,
+        ));
+    }
 }

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -181,20 +181,28 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     }
 
     #[Framework\Attributes\DataProvider('provideValidHeader')]
-    final public function testHeaderCommentFixerIsEnabledIfHeaderIsProvided(string $header): void
+    final public function testWithHeaderReturnsRuleSetWithEnabledHeaderCommentFixer(string $header): void
     {
-        $rules = static::createRuleSet($header)->rules();
+        $ruleSet = static::createRuleSet();
 
-        self::assertArrayHasKey('header_comment', $rules->toArray());
+        $mutatedRuleSet = $ruleSet->withHeader($header);
 
-        $expected = [
-            'comment_type' => 'PHPDoc',
-            'header' => \trim($header),
-            'location' => 'after_declare_strict',
-            'separate' => 'both',
-        ];
+        self::assertNotSame($ruleSet, $mutatedRuleSet);
 
-        self::assertEquals($expected, $rules->toArray()['header_comment']);
+        self::assertEquals($ruleSet->customFixers(), $mutatedRuleSet->customFixers());
+        self::assertEquals($ruleSet->name(), $mutatedRuleSet->name());
+        self::assertEquals($ruleSet->phpVersion(), $mutatedRuleSet->phpVersion());
+
+        $expected = $ruleSet->rules()->merge(Rules::fromArray([
+            'header_comment' => [
+                'comment_type' => 'PHPDoc',
+                'header' => \trim($header),
+                'location' => 'after_declare_strict',
+                'separate' => 'both',
+            ],
+        ]));
+
+        self::assertEquals($expected, $mutatedRuleSet->rules());
     }
 
     /**
@@ -228,7 +236,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
     /**
      * @throws \RuntimeException
      */
-    abstract protected static function createRuleSet(?string $header = null): RuleSet;
+    abstract protected static function createRuleSet(): RuleSet;
 
     /**
      * @return array<string, Fixer\FixerInterface>

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php53Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php53::create($header);
+        return RuleSet\Php53::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php54Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php54::create($header);
+        return RuleSet\Php54::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -37,9 +37,9 @@ final class Php55Test extends ExplicitRuleSetTestCase
         return Fixers::empty();
     }
 
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php55::create($header);
+        return RuleSet\Php55::create();
     }
 
     protected function expectedName(): Name

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php56Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php56::create($header);
+        return RuleSet\Php56::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php70Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php70::create($header);
+        return RuleSet\Php70::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php71Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php71::create($header);
+        return RuleSet\Php71::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php72Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php72::create($header);
+        return RuleSet\Php72::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php73Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php73::create($header);
+        return RuleSet\Php73::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php74Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php74::create($header);
+        return RuleSet\Php74::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php80Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php80::create($header);
+        return RuleSet\Php80::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php81Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php81::create($header);
+        return RuleSet\Php81::create();
     }
 
     protected function expectedCustomFixers(): Fixers

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -32,9 +32,9 @@ use PHPUnit\Framework;
 #[Framework\Attributes\UsesClass(Rules::class)]
 final class Php82Test extends ExplicitRuleSetTestCase
 {
-    protected static function createRuleSet(?string $header = null): RuleSet
+    protected static function createRuleSet(): RuleSet
     {
-        return RuleSet\Php82::create($header);
+        return RuleSet\Php82::create();
     }
 
     protected function expectedCustomFixers(): Fixers


### PR DESCRIPTION
This pull request

- [x] remove the optional `$header` parameter and introduce `withHeader()` mutator