### PR TITLE
Enhancement: Require and use `erickskrauch/php-cs-fixer-custom-fixers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`6.0.0...main`][6.0.0...main].
 
+### Changed
+
+- Required [`erickskrauch/php-cs-fixer-custom-fixers`](https://github.com/erickskrauch/php-cs-fixer-custom-fixers) and enabled the `ErickSkrauch/line_break_after_statements` fixer ([#889]), by [@localheinz]
+
 ## [`6.0.0`][6.0.0]
 
 For a full diff see [`5.16.0...6.0.0`][5.16.0...6.0.0].
@@ -1211,6 +1215,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#886]: https://github.com/ergebnis/php-cs-fixer-config/pull/886
 [#887]: https://github.com/ergebnis/php-cs-fixer-config/pull/887
 [#888]: https://github.com/ergebnis/php-cs-fixer-config/pull/888
+[#889]: https://github.com/ergebnis/php-cs-fixer-config/pull/889
 [#891]: https://github.com/ergebnis/php-cs-fixer-config/pull/891
 [#892]: https://github.com/ergebnis/php-cs-fixer-config/pull/892
 [#893]: https://github.com/ergebnis/php-cs-fixer-config/pull/893

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   "require": {
     "php": "~8.1.0 || ~8.2.0",
     "ext-filter": "*",
+    "erickskrauch/php-cs-fixer-custom-fixers": "~1.2.0",
     "friendsofphp/php-cs-fixer": "~3.27.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "237fa0c4ff3acebc8d98caead386aa72",
+    "content-hash": "49af1a04f7de8d2b0c651f24dff890d4",
     "packages": [
         {
             "name": "composer/pcre",
@@ -223,6 +223,68 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "erickskrauch/php-cs-fixer-custom-fixers",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erickskrauch/php-cs-fixer-custom-fixers.git",
+                "reference": "a0bef8d27904731cbd5e60ffd05fd9ce2d6850b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erickskrauch/php-cs-fixer-custom-fixers/zipball/a0bef8d27904731cbd5e60ffd05fd9ce2d6850b2",
+                "reference": "a0bef8d27904731cbd5e60ffd05fd9ce2d6850b2",
+                "shasum": ""
+            },
+            "require": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ely/php-code-style": "^1",
+                "ergebnis/composer-normalize": "^2.28",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
+                "phpspec/prophecy": "^1.15",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "phpunitgoodpractices/polyfill": "^1.5",
+                "phpunitgoodpractices/traits": "^1.9.1",
+                "symfony/phpunit-bridge": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ErickSkrauch\\PhpCsFixer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "ErickSkrauch",
+                    "email": "erickskrauch@ely.by"
+                }
+            ],
+            "description": "A set of custom fixers for PHP-CS-Fixer",
+            "homepage": "https://github.com/erickskrauch/php-cs-fixer-custom-fixers",
+            "keywords": [
+                "Code style",
+                "php-cs-fixer"
+            ],
+            "support": {
+                "issues": "https://github.com/erickskrauch/php-cs-fixer-custom-fixers/issues",
+                "source": "https://github.com/erickskrauch/php-cs-fixer-custom-fixers/tree/1.2.0"
+            },
+            "time": "2023-07-20T02:51:18+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,66 @@
       <code>$value</code>
     </PropertyTypeCoercion>
   </file>
+  <file src="src/RuleSet/Php53.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php54.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php55.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php56.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php70.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php71.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php72.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php73.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php74.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php80.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php81.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/RuleSet/Php82.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
   <file src="src/Rules.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[\array_merge(
@@ -52,6 +112,66 @@
       <code>getFixers</code>
       <code>new FixerFactory()</code>
       <code>registerBuiltInFixers</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php53Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php54Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php55Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php56Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php70Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php71Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php72Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php73Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php74Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php80Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php81Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
+    </InternalMethod>
+  </file>
+  <file src="test/Unit/RuleSet/Php82Test.php">
+    <InternalMethod>
+      <code>new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()</code>
     </InternalMethod>
   </file>
   <file src="test/Unit/RuleSetTest.php">

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php53
 {
@@ -30,7 +31,7 @@ final class Php53
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php53
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php54
 {
@@ -30,7 +31,7 @@ final class Php54
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php54
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php55
 {
@@ -30,7 +31,7 @@ final class Php55
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php55
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php56
 {
@@ -30,7 +31,7 @@ final class Php56
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php56
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php70
 {
@@ -30,7 +31,7 @@ final class Php70
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php70
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php71
 {
@@ -30,7 +31,7 @@ final class Php71
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php71
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php72
 {
@@ -30,7 +31,7 @@ final class Php72
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php72
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php73
 {
@@ -30,7 +31,7 @@ final class Php73
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php73
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php74
 {
@@ -30,7 +31,7 @@ final class Php74
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php74
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php80
 {
@@ -30,7 +31,7 @@ final class Php80
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php80
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php81
 {
@@ -30,7 +31,7 @@ final class Php81
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php81
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -18,6 +18,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 
 final class Php82
 {
@@ -30,7 +31,7 @@ final class Php82
         );
 
         return RuleSet::create(
-            Fixers::empty(),
+            Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer()),
             Name::fromString(\sprintf(
                 'ergebnis (PHP %d.%d)',
                 $phpVersion->major()->toInt(),
@@ -38,6 +39,7 @@ final class Php82
             )),
             $phpVersion,
             Rules::fromArray([
+                'ErickSkrauch/line_break_after_statements' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php53::class)]
@@ -40,7 +41,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php54::class)]
@@ -40,7 +41,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php55::class)]
@@ -35,7 +36,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
 {
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected static function createRuleSet(): RuleSet
@@ -51,6 +52,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php56::class)]
@@ -40,7 +41,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php70::class)]
@@ -40,7 +41,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php71::class)]
@@ -40,7 +41,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php72::class)]
@@ -40,7 +41,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php73::class)]
@@ -40,7 +41,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php74::class)]
@@ -40,7 +41,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php80::class)]
@@ -40,7 +41,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php81::class)]
@@ -40,7 +41,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -19,6 +19,7 @@ use Ergebnis\PhpCsFixer\Config\Name;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Rules;
 use Ergebnis\PhpCsFixer\Config\RuleSet;
+use ErickSkrauch\PhpCsFixer;
 use PHPUnit\Framework;
 
 #[Framework\Attributes\CoversClass(RuleSet\Php82::class)]
@@ -40,7 +41,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
 
     protected function expectedCustomFixers(): Fixers
     {
-        return Fixers::empty();
+        return Fixers::fromFixers(new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer());
     }
 
     protected function expectedName(): Name
@@ -51,6 +52,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
     protected function expectedRules(): Rules
     {
         return Rules::fromArray([
+            'ErickSkrauch/line_break_after_statements' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],


### PR DESCRIPTION
This pull request

- [x] requires [`erickskrauch/php-cs-fixer-custom-fixers`](https://github.com/erickskrauch/php-cs-fixer-custom-fixers)
- [x] enables the `ErickSkrauch/line_break_after_statements` fixer