### PR TITLE
Enhancement: Enable and configure `attribute_empty_parentheses` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.3.0...main`][6.3.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#900]), by [@dependabot]
+- Enabled and configured the `attribute_empty_parentheses` fixer ([#901]), by [@localheinz]
 
 ## [`6.3.0`][6.3.0]
 
@@ -1254,6 +1255,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#896]: https://github.com/ergebnis/php-cs-fixer-config/pull/896
 [#899]: https://github.com/ergebnis/php-cs-fixer-config/pull/899
 [#900]: https://github.com/ergebnis/php-cs-fixer-config/pull/900
+[#901]: https://github.com/ergebnis/php-cs-fixer-config/pull/901
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -54,7 +54,9 @@ final class Php80
                     'syntax' => 'short',
                 ],
                 'assign_null_coalescing_to_coalesce_equal' => true,
-                'attribute_empty_parentheses' => false,
+                'attribute_empty_parentheses' => [
+                    'use_parentheses' => true,
+                ],
                 'backtick_to_shell_exec' => true,
                 'binary_operator_spaces' => [
                     'default' => 'single_space',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -54,7 +54,9 @@ final class Php81
                     'syntax' => 'short',
                 ],
                 'assign_null_coalescing_to_coalesce_equal' => true,
-                'attribute_empty_parentheses' => false,
+                'attribute_empty_parentheses' => [
+                    'use_parentheses' => true,
+                ],
                 'backtick_to_shell_exec' => true,
                 'binary_operator_spaces' => [
                     'default' => 'single_space',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -54,7 +54,9 @@ final class Php82
                     'syntax' => 'short',
                 ],
                 'assign_null_coalescing_to_coalesce_equal' => true,
-                'attribute_empty_parentheses' => false,
+                'attribute_empty_parentheses' => [
+                    'use_parentheses' => true,
+                ],
                 'backtick_to_shell_exec' => true,
                 'binary_operator_spaces' => [
                     'default' => 'single_space',

--- a/test/EndToEnd/RuleSet/Php53Test.php
+++ b/test/EndToEnd/RuleSet/Php53Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php53Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php54Test.php
+++ b/test/EndToEnd/RuleSet/Php54Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php54Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php55Test.php
+++ b/test/EndToEnd/RuleSet/Php55Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php55Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php56Test.php
+++ b/test/EndToEnd/RuleSet/Php56Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php56Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php70Test.php
+++ b/test/EndToEnd/RuleSet/Php70Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php70Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php71Test.php
+++ b/test/EndToEnd/RuleSet/Php71Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php71Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php72Test.php
+++ b/test/EndToEnd/RuleSet/Php72Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php72Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php73Test.php
+++ b/test/EndToEnd/RuleSet/Php73Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php73Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php74Test.php
+++ b/test/EndToEnd/RuleSet/Php74Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php74Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php80Test.php
+++ b/test/EndToEnd/RuleSet/Php80Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php80Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php81Test.php
+++ b/test/EndToEnd/RuleSet/Php81Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 final class Php81Test extends AbstractRuleSetTestCase
 {
 }

--- a/test/EndToEnd/RuleSet/Php82Test.php
+++ b/test/EndToEnd/RuleSet/Php82Test.php
@@ -15,7 +15,7 @@ namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
 use PHPUnit\Framework;
 
-#[Framework\Attributes\CoversNothing]
+#[Framework\Attributes\CoversNothing()]
 #[Framework\Attributes\RequiresPhp('8.2')]
 final class Php82Test extends AbstractRuleSetTestCase
 {

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -67,7 +67,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'syntax' => 'short',
             ],
             'assign_null_coalescing_to_coalesce_equal' => true,
-            'attribute_empty_parentheses' => false,
+            'attribute_empty_parentheses' => [
+                'use_parentheses' => true,
+            ],
             'backtick_to_shell_exec' => true,
             'binary_operator_spaces' => [
                 'default' => 'single_space',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -67,7 +67,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'syntax' => 'short',
             ],
             'assign_null_coalescing_to_coalesce_equal' => true,
-            'attribute_empty_parentheses' => false,
+            'attribute_empty_parentheses' => [
+                'use_parentheses' => true,
+            ],
             'backtick_to_shell_exec' => true,
             'binary_operator_spaces' => [
                 'default' => 'single_space',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -67,7 +67,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'syntax' => 'short',
             ],
             'assign_null_coalescing_to_coalesce_equal' => true,
-            'attribute_empty_parentheses' => false,
+            'attribute_empty_parentheses' => [
+                'use_parentheses' => true,
+            ],
             'backtick_to_shell_exec' => true,
             'binary_operator_spaces' => [
                 'default' => 'single_space',


### PR DESCRIPTION
This pull request

- [x] enables and configures the `attribute_empty_parentheses` fixers
- [x] runs `make coding-standards`

Follows #900.