### PR TITLE
Enhancement: Keep associative arrays sorted by key

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -35,6 +35,7 @@ $config->getFinder()
         '.build/',
         '.github/',
         '.note/',
+        'test/Fixture/',
     ])
     ->ignoreDotFiles(false)
     ->in(__DIR__);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -104,6 +104,11 @@
       <code>provideValueGreaterThanNinetyNine</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/Unit/Rector/SortAssociativeArrayByKey/SortAssociativeArrayByKeyTest.php">
+    <PossiblyUnusedMethod>
+      <code>provideData</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/Unit/RuleSet/AbstractRuleSetTestCase.php">
     <InternalClass>
       <code>new FixerFactory()</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -18,7 +18,9 @@
 
     <projectFiles>
         <directory name="src/" />
-        <directory name="test/" />
+        <directory name="test/EndToEnd/" />
+        <directory name="test/Unit/" />
+        <directory name="test/Util/" />
         <file name="rector.php" />
         <ignoreFiles>
             <directory name="vendor/" />

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/php-cs-fixer-config
  */
 
+use Ergebnis\PhpCsFixer;
 use Rector\Config;
 use Rector\Core;
 use Rector\Php81;
@@ -23,13 +24,16 @@ return static function (Config\RectorConfig $rectorConfig): void {
 
     $rectorConfig->paths([
         __DIR__ . '/src/',
-        __DIR__ . '/test/',
+        __DIR__ . '/test/EndToEnd/',
+        __DIR__ . '/test/Unit/',
+        __DIR__ . '/test/Util/',
     ]);
 
     $rectorConfig->phpVersion(Core\ValueObject\PhpVersion::PHP_81);
 
     $rectorConfig->rules([
         Php81\Rector\Property\ReadOnlyPropertyRector::class,
+        PhpCsFixer\Config\Test\Rector\SortAssociativeArrayByKey::class,
     ]);
 
     $rectorConfig->sets([

--- a/test/Fixture/Rector/SortAssociativeArrayByKey/class.php.inc
+++ b/test/Fixture/Rector/SortAssociativeArrayByKey/class.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Fixture\Rector\SortAssociativeArrayByKey;
+
+class Example
+{
+    public function data(): array
+    {
+        return [
+            'foo' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            'bar' => [
+                'quz' => 'qux',
+                'quux' => 'quuz',
+            ],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Fixture\Rector\SortAssociativeArrayByKey;
+
+class Example
+{
+    public function data(): array
+    {
+        return [
+            'bar' => [
+                'quux' => 'quuz',
+                'quz' => 'qux',
+            ],
+            'foo' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+        ];
+    }
+}
+
+?>

--- a/test/Fixture/Rector/SortAssociativeArrayByKey/file.php.inc
+++ b/test/Fixture/Rector/SortAssociativeArrayByKey/file.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Fixture\Rector\SortAssociativeArrayByKey;
+
+$data = [
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+    'bar' => [
+        'quz' => 'qux',
+        'quux' => 'quuz',
+    ],
+];
+
+?>
+-----
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Fixture\Rector\SortAssociativeArrayByKey;
+
+$data = [
+    'bar' => [
+        'quux' => 'quuz',
+        'quz' => 'qux',
+    ],
+    'foo' => [
+        'foo',
+        'bar',
+        'baz',
+    ],
+];
+
+?>

--- a/test/Fixture/Rector/SortAssociativeArrayByKey/test.php.inc
+++ b/test/Fixture/Rector/SortAssociativeArrayByKey/test.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Fixture\Rector\SortAssociativeArrayByKey;
+
+use PHPUnit\Framework;
+
+class ExampleTest extends Framework\TestCase
+{
+    public function data(): array
+    {
+        return [
+            'foo' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            'bar' => [
+                'quz' => 'qux',
+                'quux' => 'quuz',
+            ],
+        ];
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Fixture\Rector\SortAssociativeArrayByKey;
+
+use PHPUnit\Framework;
+
+class ExampleTest extends Framework\TestCase
+{
+    public function data(): array
+    {
+        return [
+            'foo' => [
+                'foo',
+                'bar',
+                'baz',
+            ],
+            'bar' => [
+                'quz' => 'qux',
+                'quux' => 'quuz',
+            ],
+        ];
+    }
+}
+
+?>

--- a/test/Rector/SortAssociativeArrayByKey.php
+++ b/test/Rector/SortAssociativeArrayByKey.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2019-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/php-cs-fixer-config
+ */
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Rector;
+
+use PhpParser\Node;
+use PHPStan\Analyser;
+use PHPStan\Reflection;
+use PHPUnit\Framework;
+use Rector\Core;
+use Symplify\RuleDocGenerator;
+
+/**
+ * @internal
+ */
+final class SortAssociativeArrayByKey extends Core\Rector\AbstractRector
+{
+    public function getRuleDefinition(): RuleDocGenerator\ValueObject\RuleDefinition
+    {
+        return new RuleDocGenerator\ValueObject\RuleDefinition(
+            'Sort associative arrays by key.',
+            [
+                new RuleDocGenerator\ValueObject\CodeSample\CodeSample(
+                    <<<'CODE_SAMPLE'
+$item = [
+    'foo' => 1,
+    'bar' => 2,
+];
+CODE_SAMPLE
+                    ,
+                    <<<'CODE_SAMPLE'
+$item = [
+    'bar' => 2,
+    'foo' => 1,
+];
+CODE_SAMPLE
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\Array_::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof Node\Expr\Array_) {
+            return null;
+        }
+
+        if ($this->isScopeInTest($node)) {
+            return null;
+        }
+
+        /** @var array<int, Node\Expr\ArrayItem> $items */
+        $items = \array_filter($node->items, static function ($item): bool {
+            if (!$item instanceof Node\Expr\ArrayItem) {
+                return false;
+            }
+
+            if (!$item->key instanceof Node\Scalar\String_) {
+                return false;
+            }
+
+            return true;
+        });
+
+        if ($items !== $node->items) {
+            return null;
+        }
+
+        \usort($items, static function (Node\Expr\ArrayItem $a, Node\Expr\ArrayItem $b): int {
+            if (!$a->key instanceof Node\Scalar\String_) {
+                throw new \RuntimeException('This should not happen.');
+            }
+
+            if (!$b->key instanceof Node\Scalar\String_) {
+                throw new \RuntimeException('This should not happen.');
+            }
+
+            return \strcmp(
+                $a->key->value,
+                $b->key->value,
+            );
+        });
+
+        $node->items = $items;
+
+        return $node;
+    }
+
+    private function isScopeInTest(Node $node): bool
+    {
+        $scope = $node->getAttribute('scope');
+
+        if (!$scope instanceof Analyser\Scope) {
+            return false;
+        }
+
+        if (!$scope->isInClass()) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if (!$classReflection instanceof Reflection\ClassReflection) {
+            return false;
+        }
+
+        if (!$classReflection->isSubclassOf(Framework\TestCase::class)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/test/Unit/Rector/SortAssociativeArrayByKey/SortAssociativeArrayByKeyTest.php
+++ b/test/Unit/Rector/SortAssociativeArrayByKey/SortAssociativeArrayByKeyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2019-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/php-cs-fixer-config
+ */
+
+namespace Ergebnis\PhpCsFixer\Config\Test\Unit\Rector\SortAssociativeArrayByKey;
+
+use Ergebnis\PhpCsFixer;
+use PHPUnit\Framework;
+use Rector\Testing;
+
+#[Framework\Attributes\CoversClass(PhpCsFixer\Config\Test\Rector\SortAssociativeArrayByKey::class)]
+final class SortAssociativeArrayByKeyTest extends Testing\PHPUnit\AbstractRectorTestCase
+{
+    #[Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/../../../Fixture/Rector/SortAssociativeArrayByKey/');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/test/Unit/Rector/SortAssociativeArrayByKey/config/configured_rule.php
+++ b/test/Unit/Rector/SortAssociativeArrayByKey/config/configured_rule.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2019-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/php-cs-fixer-config
+ */
+
+use Ergebnis\PhpCsFixer;
+use Rector\Config;
+
+return static function (Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(PhpCsFixer\Config\Test\Rector\SortAssociativeArrayByKey::class);
+};


### PR DESCRIPTION
This pull request

- [x] keeps associative arrays sorted by key

Follows #904.