### PR TITLE
Enhancement: Add `use_trait` to `token` option of `no_extra_blank_lines` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`6.8.1...main`][6.8.1...main].
 
+### Changed
+
+- Added `use_trait` to `tokens` option of `no_extra_blank_lines` fixer ([#921]), by [@localheinz]
+
 ## [`6.8.1`][6.8.1]
 
 For a full diff see [`6.8.0...6.8.1`][6.8.0...6.8.1].
@@ -1325,6 +1329,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#914]: https://github.com/ergebnis/php-cs-fixer-config/pull/914
 [#917]: https://github.com/ergebnis/php-cs-fixer-config/pull/917
 [#918]: https://github.com/ergebnis/php-cs-fixer-config/pull/918
+[#921]: https://github.com/ergebnis/php-cs-fixer-config/pull/921
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -344,6 +344,7 @@ final class Php55
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -344,6 +344,7 @@ final class Php56
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -344,6 +344,7 @@ final class Php70
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -344,6 +344,7 @@ final class Php71
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -344,6 +344,7 @@ final class Php72
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -344,6 +344,7 @@ final class Php73
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -344,6 +344,7 @@ final class Php74
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -347,6 +347,7 @@ final class Php80
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -347,6 +347,8 @@ final class Php81
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -347,6 +347,7 @@ final class Php82
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -347,6 +347,7 @@ final class Php83
                         'switch',
                         'throw',
                         'use',
+                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -366,6 +366,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -366,6 +366,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -366,6 +366,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -366,6 +366,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -366,6 +366,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -366,6 +366,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -366,6 +366,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -369,6 +369,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -369,6 +369,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -369,6 +369,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -369,6 +369,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
+                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,


### PR DESCRIPTION
This pull request

- [x] adds `use_trait` to `token` option of `no_extra_blank_lines` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.35.1/doc/rules/whitespace/no_extra_blank_lines.rst#tokens.