### PR TITLE
Enhancement: Configure `case` option of `elements` option of `class_attributes_separation` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`6.8.1...main`][6.8.1...main].
 
+### Changed
+
+- Configured `case` option of `elements` option of `class_attributes_separation` fixer ([#922]), by [@localheinz]
+
 ## [`6.8.1`][6.8.1]
 
 For a full diff see [`6.8.0...6.8.1`][6.8.0...6.8.1].
@@ -1325,6 +1329,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#914]: https://github.com/ergebnis/php-cs-fixer-config/pull/914
 [#917]: https://github.com/ergebnis/php-cs-fixer-config/pull/917
 [#918]: https://github.com/ergebnis/php-cs-fixer-config/pull/918
+[#922]: https://github.com/ergebnis/php-cs-fixer-config/pull/922
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -110,6 +110,7 @@ final class Php81
                 ],
                 'class_attributes_separation' => [
                     'elements' => [
+                        'case' => 'only_if_meta',
                         'const' => 'only_if_meta',
                         'method' => 'one',
                         'property' => 'only_if_meta',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -110,6 +110,7 @@ final class Php82
                 ],
                 'class_attributes_separation' => [
                     'elements' => [
+                        'case' => 'only_if_meta',
                         'const' => 'only_if_meta',
                         'method' => 'one',
                         'property' => 'only_if_meta',

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -110,6 +110,7 @@ final class Php83
                 ],
                 'class_attributes_separation' => [
                     'elements' => [
+                        'case' => 'only_if_meta',
                         'const' => 'only_if_meta',
                         'method' => 'one',
                         'property' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -132,6 +132,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
             'class_attributes_separation' => [
                 'elements' => [
+                    'case' => 'only_if_meta',
                     'const' => 'only_if_meta',
                     'method' => 'one',
                     'property' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -132,6 +132,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
             'class_attributes_separation' => [
                 'elements' => [
+                    'case' => 'only_if_meta',
                     'const' => 'only_if_meta',
                     'method' => 'one',
                     'property' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -132,6 +132,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             ],
             'class_attributes_separation' => [
                 'elements' => [
+                    'case' => 'only_if_meta',
                     'const' => 'only_if_meta',
                     'method' => 'one',
                     'property' => 'only_if_meta',


### PR DESCRIPTION
This pull request

- [x] configures `case` option of `elements` option of `class_attributes_separation` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.35.1/doc/rules/class_notation/class_attributes_separation.rst#elements.