### PR TITLE
Fix: Remove `get_called_class` and `get_class` options from `functions` option of `function_to_constant` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`6.8.1...main`][6.8.1...main].
 
 - Configured `case` option of `elements` option of `class_attributes_separation` fixer ([#922]), by [@localheinz]
 
+### Fixed
+
+- Removed `get_called_class` and `get_class` options from `functions` option of `function_to_constant` fixer where the resulting code would be incompatible with the target PHP version ([#923]), by [@localheinz]
+
 ## [`6.8.1`][6.8.1]
 
 For a full diff see [`6.8.0...6.8.1`][6.8.0...6.8.1].

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -224,8 +224,6 @@ final class Php53
                 ],
                 'function_to_constant' => [
                     'functions' => [
-                        'get_called_class',
-                        'get_class',
                         'php_sapi_name',
                         'phpversion',
                         'pi',

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -225,8 +225,6 @@ final class Php54
                 ],
                 'function_to_constant' => [
                     'functions' => [
-                        'get_called_class',
-                        'get_class',
                         'php_sapi_name',
                         'phpversion',
                         'pi',

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -246,8 +246,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
             ],
             'function_to_constant' => [
                 'functions' => [
-                    'get_called_class',
-                    'get_class',
                     'php_sapi_name',
                     'phpversion',
                     'pi',

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -247,8 +247,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
             ],
             'function_to_constant' => [
                 'functions' => [
-                    'get_called_class',
-                    'get_class',
                     'php_sapi_name',
                     'phpversion',
                     'pi',


### PR DESCRIPTION
This pull request

- [x] remove `get_called_class` and `get_class` options from `functions` option of `function_to_constant` fixer

💁‍♂️ The `::class` pseudo constant has only been available since PHP 5.5. For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.35.1/doc/rules/language_construct/function_to_constant.rst#functions.