### PR TITLE
Enhancement: Enable `@all` set for `sets` option of `no_alias_functions` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.8.1...main`][6.8.1...main].
 ### Changed
 
 - Configured `case` option of `elements` option of `class_attributes_separation` fixer ([#922]), by [@localheinz]
+- Enabled `@all` instead of individual sets for `sets` option of `no_alias_functions` fixer ([#923]), by [@localheinz]
 
 ### Fixed
 
@@ -1335,6 +1336,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#918]: https://github.com/ergebnis/php-cs-fixer-config/pull/918
 [#922]: https://github.com/ergebnis/php-cs-fixer-config/pull/922
 [#923]: https://github.com/ergebnis/php-cs-fixer-config/pull/923
+[#924]: https://github.com/ergebnis/php-cs-fixer-config/pull/924
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -307,8 +307,7 @@ final class Php53
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -308,8 +308,7 @@ final class Php54
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -312,8 +312,7 @@ final class Php55
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -312,8 +312,7 @@ final class Php56
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -312,8 +312,7 @@ final class Php70
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -312,8 +312,7 @@ final class Php71
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -312,8 +312,7 @@ final class Php72
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -312,8 +312,7 @@ final class Php73
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -312,8 +312,7 @@ final class Php74
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -314,8 +314,7 @@ final class Php80
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -315,8 +315,7 @@ final class Php81
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -315,8 +315,7 @@ final class Php82
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -315,8 +315,7 @@ final class Php83
                 ],
                 'no_alias_functions' => [
                     'sets' => [
-                        '@IMAP',
-                        '@internal',
+                        '@all',
                     ],
                 ],
                 'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -329,8 +329,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -330,8 +330,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -334,8 +334,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -334,8 +334,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -334,8 +334,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -334,8 +334,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -334,8 +334,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -334,8 +334,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -334,8 +334,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -336,8 +336,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -337,8 +337,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -337,8 +337,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -337,8 +337,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             ],
             'no_alias_functions' => [
                 'sets' => [
-                    '@IMAP',
-                    '@internal',
+                    '@all',
                 ],
             ],
             'no_alias_language_construct_call' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `@all` set for `sets` option of `no_alias_functions` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.35.1/doc/rules/alias/no_alias_functions.rst#sets.