### PR TITLE
Add missing brace in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This will enable and configure the [`HeaderCommentFixer`](https://github.com/Fri
 +$ruleSet = Config\RuleSet\Php82::create()->withRules(Config\Rules::fromArray([
 +    'mb_str_functions' => false,
 +    'strict_comparison' => false,
-+]);
++]));
 
  $config = Config\Factory::fromRuleSet($ruleSet);
 


### PR DESCRIPTION
This pull request

- [x] adds a missing brace in an example

