### PR TITLE
Enhancement: Enable `phpdoc_type_list`  fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.17.0...main`][6.17.0...main].
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#970]), by [@dependabot]
 - Updated `friendsofphp/php-cs-fixer` ([#971]), by [@dependabot]
+- Enabled the [`PhpCsFixerCustomFixers/phpdoc_type_list_fixer`](https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.18.0#phpdoctypelistfixer) fixer ([#972]), by [@localheinz]
 
 ## [`6.17.0`][6.17.0]
 

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -34,6 +34,7 @@ final class Php53
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php53
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -34,6 +34,7 @@ final class Php54
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php54
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -34,6 +34,7 @@ final class Php55
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php55
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -34,6 +34,7 @@ final class Php56
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php56
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -34,6 +34,7 @@ final class Php70
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php70
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -34,6 +34,7 @@ final class Php71
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php71
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -34,6 +34,7 @@ final class Php72
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php72
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -34,6 +34,7 @@ final class Php73
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php73
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -34,6 +34,7 @@ final class Php74
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php74
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -34,6 +34,7 @@ final class Php80
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php80
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -34,6 +34,7 @@ final class Php81
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php81
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -34,6 +34,7 @@ final class Php82
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php82
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -34,6 +34,7 @@ final class Php83
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\PhpdocArrayStyleFixer(),
+                new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -45,6 +46,7 @@ final class Php83
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -205,7 +205,6 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         $fixersThatAreBuiltIn = $fixerFactory->getFixers();
         $fixersThatShouldBeRegistered = static::createRuleSet()->customFixers()->toArray();
 
-        /** @var list<Fixer\FixerInterface> $fixers */
         $fixers = \array_merge(
             $fixersThatAreBuiltIn,
             $fixersThatShouldBeRegistered,

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -205,7 +205,7 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         $fixersThatAreBuiltIn = $fixerFactory->getFixers();
         $fixersThatShouldBeRegistered = static::createRuleSet()->customFixers()->toArray();
 
-        /** @var array<Fixer\FixerInterface> $fixers */
+        /** @var list<Fixer\FixerInterface> $fixers */
         $fixers = \array_merge(
             $fixersThatAreBuiltIn,
             $fixersThatShouldBeRegistered,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -45,6 +45,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -45,6 +45,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -40,6 +40,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -45,6 +45,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -45,6 +45,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -45,6 +45,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -45,6 +45,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -45,6 +45,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -45,6 +45,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -45,6 +45,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -45,6 +45,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -45,6 +45,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -45,6 +45,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\PhpdocArrayStyleFixer(),
+            new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -68,6 +69,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
+            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],


### PR DESCRIPTION
This pull request

- [x] enables the `phpdoc_type_list` fixer

Follows #970.

💁‍♂️ For reference, see https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.18.0#phpdoctypelistfixer.