### PR TITLE
Enhancement: Enable `PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`6.18.0...main`][6.18.0...main].
 
+### Changed
+
+- Enabled the `PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone` fixer ([#974]), by [@localheinz]
+
 ## [`6.18.0`][6.18.0]
 
 For a full diff see [`6.17.0...6.18.0`][6.17.0...6.18.0].
@@ -1479,6 +1483,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#971]: https://github.com/ergebnis/php-cs-fixer-config/pull/971
 [#972]: https://github.com/ergebnis/php-cs-fixer-config/pull/972
 [#973]: https://github.com/ergebnis/php-cs-fixer-config/pull/973
+[#974]: https://github.com/ergebnis/php-cs-fixer-config/pull/974
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -33,6 +33,7 @@ final class Php53
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php53
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -33,6 +33,7 @@ final class Php54
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php54
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -33,6 +33,7 @@ final class Php55
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php55
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -33,6 +33,7 @@ final class Php56
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php56
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -33,6 +33,7 @@ final class Php70
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php70
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -33,6 +33,7 @@ final class Php71
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php71
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -33,6 +33,7 @@ final class Php72
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php72
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -33,6 +33,7 @@ final class Php73
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php73
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -33,6 +33,7 @@ final class Php74
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php74
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -33,6 +33,7 @@ final class Php80
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php80
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -33,6 +33,7 @@ final class Php81
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php81
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -33,6 +33,7 @@ final class Php82
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php82
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -33,6 +33,7 @@ final class Php83
 
         return RuleSet::create(
             Fixers::fromFixers(
+                new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -45,6 +46,7 @@ final class Php83
             $phpVersion,
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
+                'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -44,6 +44,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -44,6 +44,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -39,6 +39,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -44,6 +44,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -44,6 +44,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -44,6 +44,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -44,6 +44,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -44,6 +44,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -44,6 +44,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -44,6 +44,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -44,6 +44,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -44,6 +44,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -44,6 +44,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
     protected function expectedCustomFixers(): Fixers
     {
         return Fixers::fromFixers(
+            new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -68,6 +69,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
     {
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
+            'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [


### PR DESCRIPTION
This pull request

- [x] enables the `PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone` fixer

💁‍♂️ For reference, see https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.18.0#multilinecommentopeningclosingalonefixer.