### PR TITLE
Enhancement: Enable and configure `PhpCsFixerCustomFixers/no_duplicated_array_key` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.18.0...main`][6.18.0...main].
 
 - Enabled the `PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone` fixer ([#974]), by [@localheinz]
 - Enabled the `PhpCsFixerCustomFixers/multiline_promoted_properties` fixer ([#975]), by [@localheinz]
+- Enabled the `PhpCsFixerCustomFixers/no_duplicated_array_key` fixer ([#976]), by [@localheinz]
 
 ## [`6.18.0`][6.18.0]
 
@@ -1486,6 +1487,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#973]: https://github.com/ergebnis/php-cs-fixer-config/pull/973
 [#974]: https://github.com/ergebnis/php-cs-fixer-config/pull/974
 [#975]: https://github.com/ergebnis/php-cs-fixer-config/pull/975
+[#976]: https://github.com/ergebnis/php-cs-fixer-config/pull/976
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -34,6 +34,7 @@ final class Php53
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php53
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -34,6 +34,7 @@ final class Php54
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php54
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -34,6 +34,7 @@ final class Php55
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php55
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -34,6 +34,7 @@ final class Php56
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php56
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -34,6 +34,7 @@ final class Php70
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php70
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -34,6 +34,7 @@ final class Php71
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php71
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -34,6 +34,7 @@ final class Php72
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php72
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -34,6 +34,7 @@ final class Php73
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php73
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -34,6 +34,7 @@ final class Php74
         return RuleSet::create(
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -47,6 +48,9 @@ final class Php74
             Rules::fromArray([
                 'ErickSkrauch/line_break_after_statements' => true,
                 'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
+                ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -35,6 +35,7 @@ final class Php80
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\MultilinePromotedPropertiesFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -51,6 +52,9 @@ final class Php80
                 'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                     'keep_blank_lines' => false,
                     'minimum_number_of_parameters' => 2,
+                ],
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -35,6 +35,7 @@ final class Php81
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\MultilinePromotedPropertiesFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -51,6 +52,9 @@ final class Php81
                 'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                     'keep_blank_lines' => false,
                     'minimum_number_of_parameters' => 2,
+                ],
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -35,6 +35,7 @@ final class Php82
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\MultilinePromotedPropertiesFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -51,6 +52,9 @@ final class Php82
                 'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                     'keep_blank_lines' => false,
                     'minimum_number_of_parameters' => 2,
+                ],
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -35,6 +35,7 @@ final class Php83
             Fixers::fromFixers(
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\MultilinePromotedPropertiesFixer(),
+                new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -51,6 +52,9 @@ final class Php83
                 'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                     'keep_blank_lines' => false,
                     'minimum_number_of_parameters' => 2,
+                ],
+                'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                    'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -45,6 +45,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php53Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -45,6 +45,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php54Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -40,6 +40,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php55Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -45,6 +45,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php56Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -45,6 +45,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php70Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -45,6 +45,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -45,6 +45,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -45,6 +45,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -45,6 +45,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
     {
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -70,6 +71,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         return Rules::fromArray([
             'ErickSkrauch/line_break_after_statements' => true,
             'PhpCsFixerCustomFixers/multiline_comment_opening_closing_alone' => true,
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
+            ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -46,6 +46,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\MultilinePromotedPropertiesFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -74,6 +75,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                 'keep_blank_lines' => false,
                 'minimum_number_of_parameters' => 2,
+            ],
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -46,6 +46,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\MultilinePromotedPropertiesFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -74,6 +75,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                 'keep_blank_lines' => false,
                 'minimum_number_of_parameters' => 2,
+            ],
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -46,6 +46,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\MultilinePromotedPropertiesFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -74,6 +75,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                 'keep_blank_lines' => false,
                 'minimum_number_of_parameters' => 2,
+            ],
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -46,6 +46,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
         return Fixers::fromFixers(
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\MultilinePromotedPropertiesFixer(),
+            new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -74,6 +75,9 @@ final class Php83Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/multiline_promoted_properties' => [
                 'keep_blank_lines' => false,
                 'minimum_number_of_parameters' => 2,
+            ],
+            'PhpCsFixerCustomFixers/no_duplicated_array_key' => [
+                'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,


### PR DESCRIPTION
This pull request

- [x] enables and configures the `PhpCsFixerCustomFixers/no_duplicated_array_key` fixer

💁‍♂️ For reference, see https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.18.0#noduplicatedarraykeyfixer.