### PR TITLE
Enhancement: Enable `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`6.18.0...main`][6.18.0...main].
 - Enabled the `PhpCsFixerCustomFixers/multiline_promoted_properties` fixer ([#975]), by [@localheinz]
 - Enabled the `PhpCsFixerCustomFixers/no_duplicated_array_key` fixer ([#976]), by [@localheinz]
 - Enabled the `PhpCsFixerCustomFixers/no_duplicated_imports` fixer ([#977]), by [@localheinz]
+- Enabled the `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer ([#978]), by [@localheinz]
 
 ## [`6.18.0`][6.18.0]
 
@@ -1490,6 +1491,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#975]: https://github.com/ergebnis/php-cs-fixer-config/pull/975
 [#976]: https://github.com/ergebnis/php-cs-fixer-config/pull/976
 [#977]: https://github.com/ergebnis/php-cs-fixer-config/pull/977
+[#978]: https://github.com/ergebnis/php-cs-fixer-config/pull/978
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -36,6 +36,7 @@ final class Php53
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php53
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -36,6 +36,7 @@ final class Php54
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php54
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -36,6 +36,7 @@ final class Php55
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php55
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -36,6 +36,7 @@ final class Php56
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php56
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -36,6 +36,7 @@ final class Php70
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php70
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -36,6 +36,7 @@ final class Php71
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php71
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -36,6 +36,7 @@ final class Php72
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php72
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -36,6 +36,7 @@ final class Php73
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php73
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -36,6 +36,7 @@ final class Php74
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -53,6 +54,7 @@ final class Php74
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -37,6 +37,7 @@ final class Php80
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -58,6 +59,7 @@ final class Php80
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -37,6 +37,7 @@ final class Php81
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -58,6 +59,7 @@ final class Php81
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -37,6 +37,7 @@ final class Php82
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -58,6 +59,7 @@ final class Php82
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -37,6 +37,7 @@ final class Php83
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
+                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -58,6 +59,7 @@ final class Php83
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -47,6 +47,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -47,6 +47,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -42,6 +42,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -47,6 +47,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -47,6 +47,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -47,6 +47,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -47,6 +47,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -47,6 +47,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -47,6 +47,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -76,6 +77,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -48,6 +48,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -81,6 +82,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -48,6 +48,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -81,6 +82,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -48,6 +48,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -81,6 +82,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -48,6 +48,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
+            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -81,6 +82,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'align_multiline_comment' => [


### PR DESCRIPTION
This pull request

- [x] enables the `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer

💁‍♂️ For reference, see https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.18.0#noimportfromglobalnamespacefixer.