### PR TITLE
Enhancement: Enable `PhpCsFixerCustomFixers/phpdoc_types_comma_spaces` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`6.18.0...main`][6.18.0...main].
 - Enabled the `PhpCsFixerCustomFixers/no_duplicated_array_key` fixer ([#976]), by [@localheinz]
 - Enabled the `PhpCsFixerCustomFixers/no_duplicated_imports` fixer ([#977]), by [@localheinz]
 - Enabled the `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer ([#978]), by [@localheinz]
+- Enabled the `PhpCsFixerCustomFixers/phpdoc_types_comma_spaces` fixer ([#979]), by [@localheinz]
 
 ## [`6.18.0`][6.18.0]
 
@@ -1492,6 +1493,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#976]: https://github.com/ergebnis/php-cs-fixer-config/pull/976
 [#977]: https://github.com/ergebnis/php-cs-fixer-config/pull/977
 [#978]: https://github.com/ergebnis/php-cs-fixer-config/pull/978
+[#979]: https://github.com/ergebnis/php-cs-fixer-config/pull/979
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -39,6 +39,7 @@ final class Php53
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php53
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -39,6 +39,7 @@ final class Php54
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php54
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -39,6 +39,7 @@ final class Php55
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php55
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -39,6 +39,7 @@ final class Php56
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php56
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -39,6 +39,7 @@ final class Php70
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php70
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -39,6 +39,7 @@ final class Php71
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php71
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -39,6 +39,7 @@ final class Php72
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php72
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -39,6 +39,7 @@ final class Php73
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php73
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -39,6 +39,7 @@ final class Php74
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php74
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -40,6 +40,7 @@ final class Php80
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -62,6 +63,7 @@ final class Php80
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -40,6 +40,7 @@ final class Php81
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -62,6 +63,7 @@ final class Php81
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -40,6 +40,7 @@ final class Php82
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -62,6 +63,7 @@ final class Php82
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -40,6 +40,7 @@ final class Php83
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypeListFixer(),
+                new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -62,6 +63,7 @@ final class Php83
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+                'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
                 ],

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -50,6 +50,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -50,6 +50,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -45,6 +45,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -50,6 +50,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -50,6 +50,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -50,6 +50,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -50,6 +50,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -50,6 +50,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -50,6 +50,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -51,6 +51,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -85,6 +86,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -51,6 +51,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -85,6 +86,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -51,6 +51,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -85,6 +86,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -51,6 +51,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypeListFixer(),
+            new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -85,6 +86,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
+            'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
             ],


### PR DESCRIPTION
This pull request

- [x] enables the nable `PhpCsFixerCustomFixers/phpdoc_types_comma_spaces` fixer

💁‍♂️ For reference, see https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.18.0#phpdoctypescommaspacesfixer.