### PR TITLE
Enhancement: Enable `multiline_string_to_heredoc` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.19.0...main`][6.19.0...main].
 
 - Updated `erickskrauch/php-cs-fixer-custom-fixers` ([#984]), by [@dependabot]
 - Updated `friendsofphp/php-cs-fixer` ([#993]), by [@dependabot]
+- Enabled the `multiline_string_to_heredoc` fixer ([#994]), by [@localheinz]
 
 ## [`6.19.0`][6.19.0]
 
@@ -1507,6 +1508,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#979]: https://github.com/ergebnis/php-cs-fixer-config/pull/979
 [#984]: https://github.com/ergebnis/php-cs-fixer-config/pull/984
 [#993]: https://github.com/ergebnis/php-cs-fixer-config/pull/993
+[#994]: https://github.com/ergebnis/php-cs-fixer-config/pull/994
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -316,7 +316,7 @@ final class Php53
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -317,7 +317,7 @@ final class Php54
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -321,7 +321,7 @@ final class Php55
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -321,7 +321,7 @@ final class Php56
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -321,7 +321,7 @@ final class Php70
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -321,7 +321,7 @@ final class Php71
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -321,7 +321,7 @@ final class Php72
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -321,7 +321,7 @@ final class Php73
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -321,7 +321,7 @@ final class Php74
                 'modernize_strpos' => false,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -328,7 +328,7 @@ final class Php80
                 'modernize_strpos' => true,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -329,7 +329,7 @@ final class Php81
                 'modernize_strpos' => true,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -329,7 +329,7 @@ final class Php82
                 'modernize_strpos' => true,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -329,7 +329,7 @@ final class Php83
                 'modernize_strpos' => true,
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,
-                'multiline_string_to_heredoc' => false,
+                'multiline_string_to_heredoc' => true,
                 'multiline_whitespace_before_semicolons' => [
                     'strategy' => 'no_multi_line',
                 ],

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -339,7 +339,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -340,7 +340,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -344,7 +344,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -344,7 +344,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -344,7 +344,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -344,7 +344,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -344,7 +344,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -344,7 +344,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -344,7 +344,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => false,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -351,7 +351,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -352,7 +352,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -352,7 +352,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -352,7 +352,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             'modernize_strpos' => true,
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,
-            'multiline_string_to_heredoc' => false,
+            'multiline_string_to_heredoc' => true,
             'multiline_whitespace_before_semicolons' => [
                 'strategy' => 'no_multi_line',
             ],


### PR DESCRIPTION
This pull request

- [x] enables the `multiline_string_to_heredoc` fixer

Follows #993.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.47.0/doc/rules/string_notation/multiline_string_to_heredoc.rst.