### PR TITLE
Enhancement: Enable `phpdoc_list_type` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.20.0...main`][6.20.0...main].
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#996]), by [@dependabot]
 - Updated `friendsofphp/php-cs-fixer` ([#1005]), by [@dependabot]
+- Enabled the `phpdoc_list_type` instead of the `PhpCsFixerCustomFixers/phpdoc_type_list` fixer ([#1006]), by [@localheinz]
 
 ### Fixed
 

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -38,7 +38,6 @@ final class Php53
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php53
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -590,7 +588,7 @@ final class Php53
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -38,7 +38,6 @@ final class Php54
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php54
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -591,7 +589,7 @@ final class Php54
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -38,7 +38,6 @@ final class Php55
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php55
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -597,7 +595,7 @@ final class Php55
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -38,7 +38,6 @@ final class Php56
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php56
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -597,7 +595,7 @@ final class Php56
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -38,7 +38,6 @@ final class Php70
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php70
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -595,7 +593,7 @@ final class Php70
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -38,7 +38,6 @@ final class Php71
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php71
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -597,7 +595,7 @@ final class Php71
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -38,7 +38,6 @@ final class Php72
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php72
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -597,7 +595,7 @@ final class Php72
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -38,7 +38,6 @@ final class Php73
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php73
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -597,7 +595,7 @@ final class Php73
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -38,7 +38,6 @@ final class Php74
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -57,7 +56,6 @@ final class Php74
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -597,7 +595,7 @@ final class Php74
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -39,7 +39,6 @@ final class Php80
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -62,7 +61,6 @@ final class Php80
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -607,7 +605,7 @@ final class Php80
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -39,7 +39,6 @@ final class Php81
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -62,7 +61,6 @@ final class Php81
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -609,7 +607,7 @@ final class Php81
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -39,7 +39,6 @@ final class Php82
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -62,7 +61,6 @@ final class Php82
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -609,7 +607,7 @@ final class Php82
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -39,7 +39,6 @@ final class Php83
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
-                new Fixer\PhpdocTypeListFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -62,7 +61,6 @@ final class Php83
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-                'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -609,7 +607,7 @@ final class Php83
                     'method' => 'multi',
                     'property' => 'multi',
                 ],
-                'phpdoc_list_type' => false,
+                'phpdoc_list_type' => true,
                 'phpdoc_no_access' => true,
                 'phpdoc_no_alias_tag' => [
                     'replacements' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -49,7 +49,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -613,7 +611,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -49,7 +49,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -614,7 +612,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -44,7 +44,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -620,7 +618,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -49,7 +49,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -620,7 +618,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -49,7 +49,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -618,7 +616,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -49,7 +49,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -620,7 +618,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -49,7 +49,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -620,7 +618,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -49,7 +49,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -620,7 +618,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -49,7 +49,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -80,7 +79,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -620,7 +618,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -50,7 +50,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -85,7 +84,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -630,7 +628,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -50,7 +50,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -85,7 +84,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -632,7 +630,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -50,7 +50,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -85,7 +84,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -632,7 +630,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -50,7 +50,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
-            new Fixer\PhpdocTypeListFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -85,7 +84,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
-            'PhpCsFixerCustomFixers/phpdoc_type_list' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -632,7 +630,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'method' => 'multi',
                 'property' => 'multi',
             ],
-            'phpdoc_list_type' => false,
+            'phpdoc_list_type' => true,
             'phpdoc_no_access' => true,
             'phpdoc_no_alias_tag' => [
                 'replacements' => [


### PR DESCRIPTION
This pull request

- [x] enables the `phpdoc_list_type` fixer

Follows #1005.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.49.0/doc/rules/phpdoc/phpdoc_list_type.rst.