### PR TITLE
Enhancement: Enable and configure `global_namespace_import` instead of `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.21.0...main`][6.21.0...main].
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1009]), by [@dependabot]
 - Disabled the `fully_qualified_strict_types` fixer ([#1010]), by [@localheinz]
+- Enabled and configured the `global_namespace_import` instead of the `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer ([#1011]), by [@localheinz]
 
 ## [`6.21.0`][6.21.0]
 

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -36,7 +36,6 @@ final class Php53
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php53
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -246,7 +244,11 @@ final class Php53
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -36,7 +36,6 @@ final class Php54
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php54
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -247,7 +245,11 @@ final class Php54
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -36,7 +36,6 @@ final class Php55
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php55
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php55
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -36,7 +36,6 @@ final class Php56
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php56
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php56
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -36,7 +36,6 @@ final class Php70
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php70
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php70
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -36,7 +36,6 @@ final class Php71
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php71
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php71
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -36,7 +36,6 @@ final class Php72
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php72
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php72
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -36,7 +36,6 @@ final class Php73
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php73
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php73
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -36,7 +36,6 @@ final class Php74
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -54,7 +53,6 @@ final class Php74
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -251,7 +249,11 @@ final class Php74
                     ],
                 ],
                 'get_class_to_class_keyword' => false,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -37,7 +37,6 @@ final class Php80
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -59,7 +58,6 @@ final class Php80
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -258,7 +256,11 @@ final class Php80
                     ],
                 ],
                 'get_class_to_class_keyword' => true,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -37,7 +37,6 @@ final class Php81
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -59,7 +58,6 @@ final class Php81
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -259,7 +257,11 @@ final class Php81
                     ],
                 ],
                 'get_class_to_class_keyword' => true,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -37,7 +37,6 @@ final class Php82
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -59,7 +58,6 @@ final class Php82
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -259,7 +257,11 @@ final class Php82
                     ],
                 ],
                 'get_class_to_class_keyword' => true,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -37,7 +37,6 @@ final class Php83
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\NoImportFromGlobalNamespaceFixer(),
                 new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -59,7 +58,6 @@ final class Php83
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
                 'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
@@ -259,7 +257,11 @@ final class Php83
                     ],
                 ],
                 'get_class_to_class_keyword' => true,
-                'global_namespace_import' => false,
+                'global_namespace_import' => [
+                    'import_classes' => false,
+                    'import_constants' => false,
+                    'import_functions' => false,
+                ],
                 'group_import' => false,
                 'header_comment' => false,
                 'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -47,7 +47,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -269,7 +267,11 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -47,7 +47,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -270,7 +268,11 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -42,7 +42,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -47,7 +47,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -47,7 +47,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -47,7 +47,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -47,7 +47,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -47,7 +47,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -47,7 +47,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -77,7 +76,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -274,7 +272,11 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => false,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -48,7 +48,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -82,7 +81,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -281,7 +279,11 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => true,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -48,7 +48,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -82,7 +81,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -282,7 +280,11 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => true,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -48,7 +48,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -82,7 +81,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -282,7 +280,11 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => true,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -48,7 +48,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\NoImportFromGlobalNamespaceFixer(),
             new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
@@ -82,7 +81,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/no_import_from_global_namespace' => true,
             'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
@@ -282,7 +280,11 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'get_class_to_class_keyword' => true,
-            'global_namespace_import' => false,
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'group_import' => false,
             'header_comment' => false,
             'heredoc_closing_marker' => false,


### PR DESCRIPTION
This pull request

- [x] enables and configure `global_namespace_import` instead of `PhpCsFixerCustomFixers/no_import_from_global_namespace` fixer

Fixes #1008.

💁‍♂️ For reference, see

- https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.20.0?tab=readme-ov-file#noimportfromglobalnamespacefixer
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.49.0/doc/rules/import/global_namespace_import.rst