### PR TITLE
Enhancement: Enable `phpdoc_array_type` instead of `PhpCsFixerCustomFixers/phpdoc_array_style` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.22.0...main`][6.22.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#1021]), by [@dependabot]
+- Enabled the `phpdoc_array_type` instead of the `PhpCsFixerCustomFixers/phpdoc_array_style` fixer ([#1022]), by [@localheinz]
 
 ## [`6.22.0`][6.22.0]
 
@@ -1553,6 +1554,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1009]: https://github.com/ergebnis/php-cs-fixer-config/pull/1009
 [#1010]: https://github.com/ergebnis/php-cs-fixer-config/pull/1010
 [#1021]: https://github.com/ergebnis/php-cs-fixer-config/pull/1021
+[#1022]: https://github.com/ergebnis/php-cs-fixer-config/pull/1022
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -36,7 +36,6 @@ final class Php53
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php53
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -547,7 +545,7 @@ final class Php53
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -36,7 +36,6 @@ final class Php54
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php54
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -548,7 +546,7 @@ final class Php54
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -36,7 +36,6 @@ final class Php55
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php55
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -554,7 +552,7 @@ final class Php55
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -36,7 +36,6 @@ final class Php56
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php56
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -554,7 +552,7 @@ final class Php56
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -36,7 +36,6 @@ final class Php70
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php70
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -552,7 +550,7 @@ final class Php70
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -36,7 +36,6 @@ final class Php71
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php71
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -554,7 +552,7 @@ final class Php71
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -36,7 +36,6 @@ final class Php72
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php72
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -554,7 +552,7 @@ final class Php72
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -36,7 +36,6 @@ final class Php73
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php73
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -554,7 +552,7 @@ final class Php73
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -36,7 +36,6 @@ final class Php74
                 new Fixer\MultilineCommentOpeningClosingAloneFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -53,7 +52,6 @@ final class Php74
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -554,7 +552,7 @@ final class Php74
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -37,7 +37,6 @@ final class Php80
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -58,7 +57,6 @@ final class Php80
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -564,7 +562,7 @@ final class Php80
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -37,7 +37,6 @@ final class Php81
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -58,7 +57,6 @@ final class Php81
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -566,7 +564,7 @@ final class Php81
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -37,7 +37,6 @@ final class Php82
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -58,7 +57,6 @@ final class Php82
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -566,7 +564,7 @@ final class Php82
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -37,7 +37,6 @@ final class Php83
                 new Fixer\MultilinePromotedPropertiesFixer(),
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
-                new Fixer\PhpdocArrayStyleFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
                 new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
@@ -58,7 +57,6 @@ final class Php83
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-                'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',
@@ -566,7 +564,7 @@ final class Php83
                     ],
                 ],
                 'phpdoc_annotation_without_dot' => true,
-                'phpdoc_array_type' => false,
+                'phpdoc_array_type' => true,
                 'phpdoc_indent' => true,
                 'phpdoc_inline_tag_normalizer' => [
                     'tags' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -47,7 +47,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -570,7 +568,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -47,7 +47,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -571,7 +569,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -42,7 +42,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -577,7 +575,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -47,7 +47,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -577,7 +575,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -47,7 +47,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -575,7 +573,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -47,7 +47,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -577,7 +575,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -47,7 +47,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -577,7 +575,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -47,7 +47,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -577,7 +575,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -47,7 +47,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
             new Fixer\MultilineCommentOpeningClosingAloneFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -76,7 +75,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -577,7 +575,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -48,7 +48,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -81,7 +80,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -587,7 +585,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -48,7 +48,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -81,7 +80,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -589,7 +587,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -48,7 +48,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -81,7 +80,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -589,7 +587,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -48,7 +48,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
             new Fixer\MultilinePromotedPropertiesFixer(),
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
-            new Fixer\PhpdocArrayStyleFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
             new PhpCsFixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
@@ -81,7 +80,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
-            'PhpCsFixerCustomFixers/phpdoc_array_style' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',
@@ -589,7 +587,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 ],
             ],
             'phpdoc_annotation_without_dot' => true,
-            'phpdoc_array_type' => false,
+            'phpdoc_array_type' => true,
             'phpdoc_indent' => true,
             'phpdoc_inline_tag_normalizer' => [
                 'tags' => [


### PR DESCRIPTION
This pull request

- [x] enables the `phpdoc_array_type` instead of the `PhpCsFixerCustomFixers/phpdoc_array_style` fixer

Follows #1021.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.50.0/doc/rules/phpdoc/phpdoc_array_type.rst.