### PR TITLE
Update PR link phpdoc_array_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ For a full diff see [`6.22.0...6.23.0`][6.22.0...6.23.0].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#1021]), by [@dependabot]
-- Enabled the `phpdoc_array_type` instead of the `PhpCsFixerCustomFixers/phpdoc_array_style` fixer ([#1022]), by [@localheinz]
+- Enabled the `phpdoc_array_type` instead of the `PhpCsFixerCustomFixers/phpdoc_array_style` fixer ([#1023]), by [@localheinz]
 
 ## [`6.22.0`][6.22.0]
 
@@ -1560,7 +1560,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1009]: https://github.com/ergebnis/php-cs-fixer-config/pull/1009
 [#1010]: https://github.com/ergebnis/php-cs-fixer-config/pull/1010
 [#1021]: https://github.com/ergebnis/php-cs-fixer-config/pull/1021
-[#1022]: https://github.com/ergebnis/php-cs-fixer-config/pull/1022
+[#1023]: https://github.com/ergebnis/php-cs-fixer-config/pull/1023
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler


### PR DESCRIPTION
https://github.com/ergebnis/php-cs-fixer-config/pull/1022 is not the PR where `phpdoc_array_type` was enabled

https://github.com/ergebnis/php-cs-fixer-config/pull/1023 should me documented