### PR TITLE
Enhancement: Enable `namespaces` option of `no_unneeded_braces` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.23.0...main`][6.23.0...main].
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1025]), by [@dependabot]
 - Updated `friendsofphp/php-cs-fixer` ([#1026]), by [@dependabot]
+- Enabled the `namespaces` option of `no_uneeded_braces` fixer ([#1036]), by [@localheinz]
 
 ## [`6.23.0`][6.23.0]
 
@@ -1569,6 +1570,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1023]: https://github.com/ergebnis/php-cs-fixer-config/pull/1023
 [#1025]: https://github.com/ergebnis/php-cs-fixer-config/pull/1025
 [#1026]: https://github.com/ergebnis/php-cs-fixer-config/pull/1026
+[#1036]: https://github.com/ergebnis/php-cs-fixer-config/pull/1036
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -387,7 +387,7 @@ final class Php53
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -388,7 +388,7 @@ final class Php54
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -392,7 +392,7 @@ final class Php55
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -392,7 +392,7 @@ final class Php56
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -392,7 +392,7 @@ final class Php70
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -392,7 +392,7 @@ final class Php71
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -392,7 +392,7 @@ final class Php72
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -392,7 +392,7 @@ final class Php73
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -392,7 +392,7 @@ final class Php74
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -400,7 +400,7 @@ final class Php80
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -401,7 +401,7 @@ final class Php81
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -401,7 +401,7 @@ final class Php82
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -401,7 +401,7 @@ final class Php83
                 'no_trailing_whitespace_in_comment' => true,
                 'no_trailing_whitespace_in_string' => true,
                 'no_unneeded_braces' => [
-                    'namespaces' => false,
+                    'namespaces' => true,
                 ],
                 'no_unneeded_control_parentheses' => [
                     'statements' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -410,7 +410,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -411,7 +411,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -415,7 +415,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -415,7 +415,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -415,7 +415,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -415,7 +415,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -415,7 +415,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -415,7 +415,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -415,7 +415,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -423,7 +423,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -424,7 +424,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -424,7 +424,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -424,7 +424,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             'no_trailing_whitespace_in_comment' => true,
             'no_trailing_whitespace_in_string' => true,
             'no_unneeded_braces' => [
-                'namespaces' => false,
+                'namespaces' => true,
             ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [


### PR DESCRIPTION
This pull request

- [x] enables the `namespaces` option of the `no_unneeded_braces` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.51.0/doc/rules/control_structure/no_unneeded_braces.rst.