### PR TITLE
Enhancement: Enable and configure `ordered_attributes` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.26.0...main`][6.26.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#1058]), by [@dependabot]
+- Enabled and configured the `ordered_attributes` fixer ([#1060]), by [@localheinz]
 
 ## [`6.26.0`][6.26.0]
 
@@ -1615,6 +1616,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1039]: https://github.com/ergebnis/php-cs-fixer-config/pull/1039
 [#1051]: https://github.com/ergebnis/php-cs-fixer-config/pull/1051
 [#1058]: https://github.com/ergebnis/php-cs-fixer-config/pull/1058
+[#1060]: https://github.com/ergebnis/php-cs-fixer-config/pull/1060
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -452,7 +452,10 @@ final class Php80
                     'only_booleans' => true,
                     'position' => 'beginning',
                 ],
-                'ordered_attributes' => false,
+                'ordered_attributes' => [
+                    'order' => [],
+                    'sort_algorithm' => 'alpha',
+                ],
                 'ordered_class_elements' => [
                     'case_sensitive' => false,
                     'order' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -453,7 +453,10 @@ final class Php81
                     'only_booleans' => true,
                     'position' => 'beginning',
                 ],
-                'ordered_attributes' => false,
+                'ordered_attributes' => [
+                    'order' => [],
+                    'sort_algorithm' => 'alpha',
+                ],
                 'ordered_class_elements' => [
                     'case_sensitive' => false,
                     'order' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -453,7 +453,10 @@ final class Php82
                     'only_booleans' => true,
                     'position' => 'beginning',
                 ],
-                'ordered_attributes' => false,
+                'ordered_attributes' => [
+                    'order' => [],
+                    'sort_algorithm' => 'alpha',
+                ],
                 'ordered_class_elements' => [
                     'case_sensitive' => false,
                     'order' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -453,7 +453,10 @@ final class Php83
                     'only_booleans' => true,
                     'position' => 'beginning',
                 ],
-                'ordered_attributes' => false,
+                'ordered_attributes' => [
+                    'order' => [],
+                    'sort_algorithm' => 'alpha',
+                ],
                 'ordered_class_elements' => [
                     'case_sensitive' => false,
                     'order' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -475,7 +475,10 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'only_booleans' => true,
                 'position' => 'beginning',
             ],
-            'ordered_attributes' => false,
+            'ordered_attributes' => [
+                'order' => [],
+                'sort_algorithm' => 'alpha',
+            ],
             'ordered_class_elements' => [
                 'case_sensitive' => false,
                 'order' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -476,7 +476,10 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'only_booleans' => true,
                 'position' => 'beginning',
             ],
-            'ordered_attributes' => false,
+            'ordered_attributes' => [
+                'order' => [],
+                'sort_algorithm' => 'alpha',
+            ],
             'ordered_class_elements' => [
                 'case_sensitive' => false,
                 'order' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -476,7 +476,10 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'only_booleans' => true,
                 'position' => 'beginning',
             ],
-            'ordered_attributes' => false,
+            'ordered_attributes' => [
+                'order' => [],
+                'sort_algorithm' => 'alpha',
+            ],
             'ordered_class_elements' => [
                 'case_sensitive' => false,
                 'order' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -476,7 +476,10 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'only_booleans' => true,
                 'position' => 'beginning',
             ],
-            'ordered_attributes' => false,
+            'ordered_attributes' => [
+                'order' => [],
+                'sort_algorithm' => 'alpha',
+            ],
             'ordered_class_elements' => [
                 'case_sensitive' => false,
                 'order' => [


### PR DESCRIPTION
This pull request

- [x] enables and configures the `ordered_attributes` fixer

Follows #1058.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.55.0/doc/rules/attribute_notation/ordered_attributes.rst.