### PR TITLE
Automatic version detection

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$ruleSet = PhpCsFixer\Config\RuleSet\Php74::create()->withHeader($license->header());
+$ruleSet = PhpCsFixer\Config\RuleSet\PhpAuto::create()->withHeader($license->header());
 
 $config = PhpCsFixer\Config\Factory::fromRuleSet($ruleSet);
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ composer require --dev ergebnis/php-cs-fixer-config
 
 ### Configuration
 
-Pick one of the rule sets:
+Use [`Ergebnis\PhpCsFixer\RuleSet\PhpAuto`](src/RuleSet/PhpAuto.php) to find the best rule set for the minimum PHP
+version defined in your `composer.json` file or pick one of the rule sets:
 
 - [`Ergebnis\PhpCsFixer\RuleSet\Php53`](src/RuleSet/Php53.php)
 - [`Ergebnis\PhpCsFixer\RuleSet\Php54`](src/RuleSet/Php54.php)
@@ -51,7 +52,7 @@ declare(strict_types=1);
 
 use Ergebnis\PhpCsFixer\Config;
 
-$ruleSet = Config\RuleSet\Php83::create();
+$ruleSet = Config\RuleSet\PhpAuto::create();
 
 $config = Config\Factory::fromRuleSet($ruleSet);
 
@@ -90,8 +91,8 @@ All configuration examples use the caching feature, and if you want to use it as
 +@see https://github.com/ergebnis/php-cs-fixer-config
 +EOF;
 
--$ruleSet = Config\RuleSet\Php83::create();
-+$ruleSet = Config\RuleSet\Php83::create()->withHeader($header);
+-$ruleSet = Config\RuleSet\PhpAuto::create();
++$ruleSet = Config\RuleSet\PhpAuto::create()->withHeader($header);
 
  $config = Config\Factory::fromRuleSet($ruleSet);
 
@@ -129,8 +130,8 @@ This will enable and configure the [`HeaderCommentFixer`](https://github.com/Fri
 
  use Ergebnis\PhpCsFixer\Config;
 
--$ruleSet = Config\RuleSet\Php83::create();
-+$ruleSet = Config\RuleSet\Php83::create()->withRules(Config\Rules::fromArray([
+-$ruleSet = Config\RuleSet\PhpAuto::create();
++$ruleSet = Config\RuleSet\PhpAuto::create()->withRules(Config\Rules::fromArray([
 +    'mb_str_functions' => false,
 +    'strict_comparison' => false,
 +]));
@@ -155,8 +156,8 @@ This will enable and configure the [`HeaderCommentFixer`](https://github.com/Fri
  use Ergebnis\PhpCsFixer\Config;
  use FooBar\Fixer;
 
--$ruleSet = Config\RuleSet\Php83::create();
-+$ruleSet = Config\RuleSet\Php83::create()
+-$ruleSet = Config\RuleSet\PhpAuto::create();
++$ruleSet = Config\RuleSet\PhpAuto::create()
 +    ->withCustomFixers(Config\Fixers::fromFixers(
 +        new Fixer\BarBazFixer(),
 +        new Fixer\QuzFixer(),

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,8 @@
   "require": {
     "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
     "ext-filter": "*",
+    "ext-json": "*",
+    "composer/semver": "^3.4",
     "erickskrauch/php-cs-fixer-custom-fixers": "~1.3.0",
     "friendsofphp/php-cs-fixer": "~3.62.0",
     "kubawerlos/php-cs-fixer-custom-fixers": "~3.21.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbb15ff5763723b518ce1571a23999b5",
+    "content-hash": "b26396fd3ca21067183a89e25107a4c9",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -7334,7 +7334,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-        "ext-filter": "*"
+        "ext-filter": "*",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -23,11 +23,9 @@ final class Factory
      *
      * @throws \RuntimeException
      */
-    public static function fromRuleSet(RuleSet $ruleSet): Config
+    public static function fromRuleSet(RuleSet $ruleSet, bool $checkCurrentPhpVersion = true): Config
     {
-        $currentPhpVersion = PhpVersion::current();
-
-        if ($currentPhpVersion->isSmallerThan($ruleSet->phpVersion())) {
+        if ($checkCurrentPhpVersion && ($currentPhpVersion = PhpVersion::current())->isSmallerThan($ruleSet->phpVersion())) {
             throw new \RuntimeException(\sprintf(
                 'Current PHP version "%s" is smaller than targeted PHP version "%s".',
                 $currentPhpVersion->toString(),

--- a/src/PhpVersion.php
+++ b/src/PhpVersion.php
@@ -115,6 +115,15 @@ final class PhpVersion
         return $this->major->toInt() * 10_000 + $this->minor->toInt() * 100 + $this->patch->toInt();
     }
 
+    public function toLanguageLevelInt(): int
+    {
+        if (9 < $this->minor->toInt()) {
+            throw new \LogicException('PHP minor version must be less than 10');
+        }
+
+        return ($this->major->toInt() * 10) + $this->minor->toInt();
+    }
+
     public function toString(): string
     {
         return \sprintf(

--- a/src/PhpVersion.php
+++ b/src/PhpVersion.php
@@ -81,6 +81,20 @@ final class PhpVersion
         );
     }
 
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public static function fromString(string $value): self
+    {
+        $split = \explode('.', $value, 4);
+
+        return new self(
+            PhpVersion\Major::fromInt((int) ($split[0] ?? '0')),
+            PhpVersion\Minor::fromInt((int) ($split[1] ?? '0')),
+            PhpVersion\Patch::fromInt((int) ($split[2] ?? '0')),
+        );
+    }
+
     public function major(): PhpVersion\Major
     {
         return $this->major;

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php53
+final class Php53 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php54
+final class Php54 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php55
+final class Php55 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php56
+final class Php56 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php70
+final class Php70 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php71
+final class Php71 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php72
+final class Php72 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php73
+final class Php73 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php74
+final class Php74 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php80
+final class Php80 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php81
+final class Php81 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php82
+final class Php82 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -21,7 +21,7 @@ use Ergebnis\PhpCsFixer\Config\RuleSet;
 use ErickSkrauch\PhpCsFixer;
 use PhpCsFixerCustomFixers\Fixer;
 
-final class Php83
+final class Php83 implements PhpRuleSet
 {
     public static function create(): RuleSet
     {

--- a/src/RuleSet/PhpAuto.php
+++ b/src/RuleSet/PhpAuto.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2019-2024 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/php-cs-fixer-config
+ */
+
+namespace Ergebnis\PhpCsFixer\Config\RuleSet;
+
+use Composer\Semver\VersionParser;
+use Ergebnis\PhpCsFixer\Config\PhpVersion;
+use Ergebnis\PhpCsFixer\Config\RuleSet;
+
+final class PhpAuto implements PhpRuleSet
+{
+    /**
+     * @throws \InvalidArgumentException|\JsonException|\RuntimeException
+     */
+    public static function create(): RuleSet
+    {
+        $composerFile = \getcwd() . \DIRECTORY_SEPARATOR . 'composer.json';
+        $phpVersion = self::getMinimumVersion(self::findPhpVersionSpec($composerFile));
+        $ruleSetClass = __NAMESPACE__ . "\\Php{$phpVersion->toLanguageLevelInt()}";
+
+        if (!\class_exists($ruleSetClass)) {
+            throw new \RuntimeException(
+                "Class `{$ruleSetClass}` not found: It is likely that no ruleset for PHP {$phpVersion->toString()} has been defined yet",
+            );
+        }
+
+        if (!\is_a($ruleSetClass, PhpRuleSet::class, true)) {
+            throw new \RuntimeException("Class `{$ruleSetClass}` does not implement the `PhpRuleSet` interface");
+        }
+
+        return $ruleSetClass::create();
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     * @throws \JsonException
+     */
+    private static function findPhpVersionSpec(string $file): string
+    {
+        if (!\file_exists($file)) {
+            throw new \RuntimeException("Composer file not found at {$file}");
+        }
+
+        $contents = \file_get_contents($file);
+
+        if (false === $contents) {
+            throw new \InvalidArgumentException("Composer config file is empty at {$file}");
+        }
+
+        $config = \json_decode($contents, false, 512, \JSON_THROW_ON_ERROR);
+
+        if (!\is_object($config)) {
+            throw new \InvalidArgumentException('Composer config should be an object, ' . \gettype($config) . " found in {$file}");
+        }
+
+        if (!\is_object($config->require)) {
+            throw new \InvalidArgumentException('The `require` section in the Composer config should be an object, ' . \gettype($config->require) . " found in {$file}");
+        }
+
+        if (!isset($config->require->php)) {
+            throw new \InvalidArgumentException("PHP has not been configured as a requirement in {$file}");
+        }
+
+        if (!\is_string($config->require->php)) {
+            throw new \InvalidArgumentException('PHP version should be a string, ' . \gettype($config->require->php) . " found in {$file}");
+        }
+
+        return $config->require->php;
+    }
+
+    private static function getMinimumVersion(string $versionSpec): PhpVersion
+    {
+        return PhpVersion::fromString(
+            (new VersionParser())
+                ->parseConstraints($versionSpec)
+                ->getLowerBound()
+                ->getVersion(),
+        );
+    }
+}

--- a/src/RuleSet/PhpRuleSet.php
+++ b/src/RuleSet/PhpRuleSet.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ergebnis\PhpCsFixer\Config\RuleSet;
+
+use Ergebnis\PhpCsFixer\Config\RuleSet;
+
+interface PhpRuleSet
+{
+    public static function create(): RuleSet;
+}

--- a/test/EndToEnd/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/EndToEnd/RuleSet/AbstractRuleSetTestCase.php
@@ -58,12 +58,16 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
 
         self::assertNotNull($exitCode);
         self::assertSame(0, Console\Command\Command::FAILURE & $exitCode, \sprintf(
-            'Failed asserting that running friendsofphp/php-cs-fixer with the configuration in "%s" did not result in failure.',
+            'Failed asserting that running friendsofphp/php-cs-fixer with the configuration in "%s" did not result in failure:%s%s',
             self::className(),
+            \PHP_EOL,
+            $process->getErrorOutput() ?: $process->getOutput(),
         ));
         self::assertSame(0, Command\FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG & $exitCode, \sprintf(
-            'Failed asserting that the configuration in "%s" is considered valid by friendsofphp/php-cs-fixer.',
+            'Failed asserting that the configuration in "%s" is considered valid by friendsofphp/php-cs-fixer:%s%s',
             self::className(),
+            \PHP_EOL,
+            $process->getErrorOutput() ?: $process->getOutput(),
         ));
     }
 

--- a/test/EndToEnd/RuleSet/PhpAutoTest.php
+++ b/test/EndToEnd/RuleSet/PhpAutoTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/php-cs-fixer-config
  */
 
-namespace Ergebnis\PhpCsFixer\Config\RuleSet;
+namespace Ergebnis\PhpCsFixer\Config\Test\EndToEnd\RuleSet;
 
-use Ergebnis\PhpCsFixer\Config\RuleSet;
-
-interface PhpRuleSet
+/**
+ * @coversNothing
+ */
+final class PhpAutoTest extends AbstractRuleSetTestCase
 {
-    public static function create(): RuleSet;
 }

--- a/test/Unit/PhpVersionTest.php
+++ b/test/Unit/PhpVersionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
-use Ergebnis\DataProvider;
 use Ergebnis\PhpCsFixer\Config\PhpVersion;
 use Ergebnis\PhpCsFixer\Config\Test;
 use PHPUnit\Framework;
@@ -113,5 +112,28 @@ final class PhpVersionTest extends Framework\TestCase
         $two = PhpVersion::fromInt(\PHP_VERSION_ID + 1);
 
         self::assertTrue($one->isSmallerThan($two));
+    }
+
+    /**
+     * @dataProvider versionStringDataProvider
+     */
+    public function testVersionStringCanBeParsed(string $phpVersion, int $major, int $minor, int $patch): void
+    {
+        $phpVersion = PhpVersion::fromString($phpVersion);
+
+        self::assertSame($major, $phpVersion->major()->toInt());
+        self::assertSame($minor, $phpVersion->minor()->toInt());
+        self::assertSame($patch, $phpVersion->patch()->toInt());
+    }
+
+    public static function versionStringDataProvider(): iterable
+    {
+        yield 'empty string' => ['phpVersion' => '', 'major' => 0, 'minor' => 0, 'patch' => 0];
+
+        yield 'missing minor and patch' => ['phpVersion' => '5', 'major' => 5, 'minor' => 0, 'patch' => 0];
+
+        yield 'missing patch' => ['phpVersion' => '7.1', 'major' => 7, 'minor' => 1, 'patch' => 0];
+
+        yield 'including release' => ['phpVersion' => '7.2.3.45678', 'major' => 7, 'minor' => 2, 'patch' => 3];
     }
 }

--- a/test/Unit/PhpVersionTest.php
+++ b/test/Unit/PhpVersionTest.php
@@ -117,23 +117,52 @@ final class PhpVersionTest extends Framework\TestCase
     /**
      * @dataProvider versionStringDataProvider
      */
-    public function testVersionStringCanBeParsed(string $phpVersion, int $major, int $minor, int $patch): void
+    public function testVersionStringCanBeParsed(string $phpVersionString, PhpVersion $expectedVersion): void
     {
-        $phpVersion = PhpVersion::fromString($phpVersion);
+        $actualVersion = PhpVersion::fromString($phpVersionString);
 
-        self::assertSame($major, $phpVersion->major()->toInt());
-        self::assertSame($minor, $phpVersion->minor()->toInt());
-        self::assertSame($patch, $phpVersion->patch()->toInt());
+        self::assertEquals($expectedVersion, $actualVersion);
     }
 
+    /**
+     * @return iterable<string, array{phpVersionString: string, expectedVersion: PhpVersion}>
+     */
     public static function versionStringDataProvider(): iterable
     {
-        yield 'empty string' => ['phpVersion' => '', 'major' => 0, 'minor' => 0, 'patch' => 0];
+        yield 'empty string' => [
+            'phpVersionString' => '',
+            'expectedVersion' => PhpVersion::create(
+                PhpVersion\Major::fromInt(0),
+                PhpVersion\Minor::fromInt(0),
+                PhpVersion\Patch::fromInt(0),
+            ),
+        ];
 
-        yield 'missing minor and patch' => ['phpVersion' => '5', 'major' => 5, 'minor' => 0, 'patch' => 0];
+        yield 'missing minor and patch' => [
+            'phpVersionString' => '5',
+            'expectedVersion' => PhpVersion::create(
+                PhpVersion\Major::fromInt(5),
+                PhpVersion\Minor::fromInt(0),
+                PhpVersion\Patch::fromInt(0),
+            ),
+        ];
 
-        yield 'missing patch' => ['phpVersion' => '7.1', 'major' => 7, 'minor' => 1, 'patch' => 0];
+        yield 'missing patch' => [
+            'phpVersionString' => '7.1',
+            'expectedVersion' => PhpVersion::create(
+                PhpVersion\Major::fromInt(7),
+                PhpVersion\Minor::fromInt(1),
+                PhpVersion\Patch::fromInt(0),
+            ),
+        ];
 
-        yield 'including release' => ['phpVersion' => '7.2.3.45678', 'major' => 7, 'minor' => 2, 'patch' => 3];
+        yield 'including release' => [
+            'phpVersionString' => '7.2.3.45678',
+            'expectedVersion' => PhpVersion::create(
+                PhpVersion\Major::fromInt(7),
+                PhpVersion\Minor::fromInt(2),
+                PhpVersion\Patch::fromInt(3),
+            ),
+        ];
     }
 }


### PR DESCRIPTION
This pull request adds a new ruleset, `PhpAuto`, that picks the right ruleset based on the _minimum required PHP version_ defined in `composer.json` of the current working directory.

New dependencies added:
1. `ext-json` (backword compatible, since it was already required by php-cs-fixer)
2. `composer/semver` (supported since PHP 5.3, so it should also be fine)

Additional Changes:
- project itself now uses the new ruleset (I figured it would be less maintenance + eating your own dog food)
- updated the readme file with the same reasoning; most people would want to automate this

Design Notes:
- at first I was going for a `PHP version -> ruleset class` (e.g. `[53 => Php53::class]`) map but then I thought it would be less work to just add an interface and build the class name dynamically