### PR TITLE
Enhancement: Configure `trailing_comma_in_multiline` fixer to include `array_destructuring` in `elements` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For a full diff see [`6.35.0...main`][6.35.0...main].
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1095]), by [@dependabot]
 - Updated `friendsofphp/php-cs-fixer` ([#1102]), by [@dependabot]
+- Configured `trailing_comma_in_multiline` fixer to include `array_destructuring` in the `elements` option ([#1103]), by [@localheinz]
+
 
 ## [`6.35.0`][6.35.0]
 
@@ -1742,6 +1744,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1093]: https://github.com/ergebnis/php-cs-fixer-config/pull/1093
 [#1095]: https://github.com/ergebnis/php-cs-fixer-config/pull/1095
 [#1102]: https://github.com/ergebnis/php-cs-fixer-config/pull/1102
+[#1103]: https://github.com/ergebnis/php-cs-fixer-config/pull/1103
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -844,6 +844,7 @@ final class Php71
                 'trailing_comma_in_multiline' => [
                     'after_heredoc' => false,
                     'elements' => [
+                        'array_destructuring',
                         'arrays',
                     ],
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -844,6 +844,7 @@ final class Php72
                 'trailing_comma_in_multiline' => [
                     'after_heredoc' => false,
                     'elements' => [
+                        'array_destructuring',
                         'arrays',
                     ],
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -845,6 +845,7 @@ final class Php73
                     'after_heredoc' => false,
                     'elements' => [
                         'arguments',
+                        'array_destructuring',
                         'arrays',
                     ],
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -848,6 +848,7 @@ final class Php74
                     'after_heredoc' => false,
                     'elements' => [
                         'arguments',
+                        'array_destructuring',
                         'arrays',
                     ],
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -865,6 +865,7 @@ final class Php80
                     'after_heredoc' => false,
                     'elements' => [
                         'arguments',
+                        'array_destructuring',
                         'arrays',
                         'match',
                         'parameters',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -868,6 +868,7 @@ final class Php81
                     'after_heredoc' => false,
                     'elements' => [
                         'arguments',
+                        'array_destructuring',
                         'arrays',
                         'match',
                         'parameters',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -868,6 +868,7 @@ final class Php82
                     'after_heredoc' => false,
                     'elements' => [
                         'arguments',
+                        'array_destructuring',
                         'arrays',
                         'match',
                         'parameters',

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -868,6 +868,7 @@ final class Php83
                     'after_heredoc' => false,
                     'elements' => [
                         'arguments',
+                        'array_destructuring',
                         'arrays',
                         'match',
                         'parameters',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -867,6 +867,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'trailing_comma_in_multiline' => [
                 'after_heredoc' => false,
                 'elements' => [
+                    'array_destructuring',
                     'arrays',
                 ],
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -867,6 +867,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'trailing_comma_in_multiline' => [
                 'after_heredoc' => false,
                 'elements' => [
+                    'array_destructuring',
                     'arrays',
                 ],
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -868,6 +868,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'elements' => [
                     'arguments',
+                    'array_destructuring',
                     'arrays',
                 ],
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -871,6 +871,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'elements' => [
                     'arguments',
+                    'array_destructuring',
                     'arrays',
                 ],
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -888,6 +888,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'elements' => [
                     'arguments',
+                    'array_destructuring',
                     'arrays',
                     'match',
                     'parameters',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -891,6 +891,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'elements' => [
                     'arguments',
+                    'array_destructuring',
                     'arrays',
                     'match',
                     'parameters',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -891,6 +891,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'elements' => [
                     'arguments',
+                    'array_destructuring',
                     'arrays',
                     'match',
                     'parameters',

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -891,6 +891,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'elements' => [
                     'arguments',
+                    'array_destructuring',
                     'arrays',
                     'match',
                     'parameters',


### PR DESCRIPTION
This pull request

- [x] configures the `trailing_comma_in_multiline` fixer to include `array_destructuring` in `elements` option

Follows #1102.