### PR TITLE
Enhancement: Enable `modernize_stripos` option of `modernize_strpos` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ For a full diff see [`6.41.0...main`][6.41.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#1153]), by [@dependabot]
--
+- Enabled `modernize_stripos` option of `modernize_strpos fixer` ([#1154]), by [@localheinz]
+
 ## [`6.41.0`][6.41.0]
 
 For a full diff see [`6.40.0...6.41.0`][6.40.0...6.41.0].
@@ -1812,6 +1813,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1148]: https://github.com/ergebnis/php-cs-fixer-config/pull/1148
 [#1150]: https://github.com/ergebnis/php-cs-fixer-config/pull/1150
 [#1153]: https://github.com/ergebnis/php-cs-fixer-config/pull/1153
+[#1154]: https://github.com/ergebnis/php-cs-fixer-config/pull/1154
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -295,7 +295,7 @@ final class Php80
                 ],
                 'method_chaining_indentation' => true,
                 'modernize_strpos' => [
-                    'modernize_stripos' => false,
+                    'modernize_stripos' => true,
                 ],
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -296,7 +296,7 @@ final class Php81
                 ],
                 'method_chaining_indentation' => true,
                 'modernize_strpos' => [
-                    'modernize_stripos' => false,
+                    'modernize_stripos' => true,
                 ],
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -296,7 +296,7 @@ final class Php82
                 ],
                 'method_chaining_indentation' => true,
                 'modernize_strpos' => [
-                    'modernize_stripos' => false,
+                    'modernize_stripos' => true,
                 ],
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -296,7 +296,7 @@ final class Php83
                 ],
                 'method_chaining_indentation' => true,
                 'modernize_strpos' => [
-                    'modernize_stripos' => false,
+                    'modernize_stripos' => true,
                 ],
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -296,7 +296,7 @@ final class Php84
                 ],
                 'method_chaining_indentation' => true,
                 'modernize_strpos' => [
-                    'modernize_stripos' => false,
+                    'modernize_stripos' => true,
                 ],
                 'modernize_types_casting' => true,
                 'multiline_comment_opening_closing' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -318,7 +318,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
             'method_chaining_indentation' => true,
             'modernize_strpos' => [
-                'modernize_stripos' => false,
+                'modernize_stripos' => true,
             ],
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -319,7 +319,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
             'method_chaining_indentation' => true,
             'modernize_strpos' => [
-                'modernize_stripos' => false,
+                'modernize_stripos' => true,
             ],
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -319,7 +319,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
             'method_chaining_indentation' => true,
             'modernize_strpos' => [
-                'modernize_stripos' => false,
+                'modernize_stripos' => true,
             ],
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -319,7 +319,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             ],
             'method_chaining_indentation' => true,
             'modernize_strpos' => [
-                'modernize_stripos' => false,
+                'modernize_stripos' => true,
             ],
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -319,7 +319,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
             ],
             'method_chaining_indentation' => true,
             'modernize_strpos' => [
-                'modernize_stripos' => false,
+                'modernize_stripos' => true,
             ],
             'modernize_types_casting' => true,
             'multiline_comment_opening_closing' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `modernize_stripos` option of the `modernize_strpos` fixer

Follows #1153.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.68.0/doc/rules/alias/modernize_strpos.rst.