### PR TITLE
Enhancement: Add `constant` to `elements` option of `type_declaration_spaces` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.43.1...main`][6.43.1...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#1177]), by [@dependabot]
+- Added `constant` to `elements` option of `type_declaration_spaces` fixer ([#1178]), by [@localheinz]
 
 ## [`6.43.1`][6.43.1]
 
@@ -1882,6 +1883,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1170]: https://github.com/ergebnis/php-cs-fixer-config/pull/1170
 [#1173]: https://github.com/ergebnis/php-cs-fixer-config/pull/1173
 [#1177]: https://github.com/ergebnis/php-cs-fixer-config/pull/1177
+[#1178]: https://github.com/ergebnis/php-cs-fixer-config/pull/1178
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -853,6 +853,7 @@ final class Php71
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                     ],
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -853,6 +853,7 @@ final class Php72
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                     ],
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -854,6 +854,7 @@ final class Php73
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                     ],
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -858,6 +858,7 @@ final class Php74
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                         'property',
                     ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -879,6 +879,7 @@ final class Php80
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                         'property',
                     ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -882,6 +882,7 @@ final class Php81
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                         'property',
                     ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -882,6 +882,7 @@ final class Php82
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                         'property',
                     ],

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -882,6 +882,7 @@ final class Php83
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                         'property',
                     ],

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -882,6 +882,7 @@ final class Php84
                 'trim_array_spaces' => true,
                 'type_declaration_spaces' => [
                     'elements' => [
+                        'constant',
                         'function',
                         'property',
                     ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -876,6 +876,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                 ],
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -876,6 +876,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                 ],
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -877,6 +877,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                 ],
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -881,6 +881,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                     'property',
                 ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -902,6 +902,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                     'property',
                 ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -905,6 +905,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                     'property',
                 ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -905,6 +905,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                     'property',
                 ],

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -905,6 +905,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                     'property',
                 ],

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -905,6 +905,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
             'trim_array_spaces' => true,
             'type_declaration_spaces' => [
                 'elements' => [
+                    'constant',
                     'function',
                     'property',
                 ],


### PR DESCRIPTION
This pull request

- [x] adds `constant` to the `elements` option of the `type_declaration_spaces` fixer

Follows #1177.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.70.0/doc/rules/whitespace/type_declaration_spaces.rst.