### PR TITLE
Enhancement: Enable and configure `php_unit_data_provider_method_order` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`6.43.1...main`][6.43.1...main].
 
 - Updated `friendsofphp/php-cs-fixer` ([#1177]), by [@dependabot]
 - Added `constant` to `elements` option of `type_declaration_spaces` fixer ([#1178]), by [@localheinz]
+- Enabled and configured `php_unit_data_provider_method_order` fixer ([#1179]), by [@localheinz]
 
 ## [`6.43.1`][6.43.1]
 
@@ -1884,6 +1885,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1173]: https://github.com/ergebnis/php-cs-fixer-config/pull/1173
 [#1177]: https://github.com/ergebnis/php-cs-fixer-config/pull/1177
 [#1178]: https://github.com/ergebnis/php-cs-fixer-config/pull/1178
+[#1179]: https://github.com/ergebnis/php-cs-fixer-config/pull/1179
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -487,7 +487,9 @@ final class Php53
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => false,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -488,7 +488,9 @@ final class Php54
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => false,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -494,7 +494,9 @@ final class Php55
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => false,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -494,7 +494,9 @@ final class Php56
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => false,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -494,7 +494,9 @@ final class Php70
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => false,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -494,7 +494,9 @@ final class Php71
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -494,7 +494,9 @@ final class Php72
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -494,7 +494,9 @@ final class Php73
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -494,7 +494,9 @@ final class Php74
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -509,7 +509,9 @@ final class Php80
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -511,7 +511,9 @@ final class Php81
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -511,7 +511,9 @@ final class Php82
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -511,7 +511,9 @@ final class Php83
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -511,7 +511,9 @@ final class Php84
                         'assertSame',
                     ],
                 ],
-                'php_unit_data_provider_method_order' => false,
+                'php_unit_data_provider_method_order' => [
+                    'placement' => 'after',
+                ],
                 'php_unit_data_provider_name' => false,
                 'php_unit_data_provider_return_type' => true,
                 'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -510,7 +510,9 @@ final class Php53Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => false,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -511,7 +511,9 @@ final class Php54Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => false,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -517,7 +517,9 @@ final class Php55Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => false,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -517,7 +517,9 @@ final class Php56Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => false,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -517,7 +517,9 @@ final class Php70Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => false,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -517,7 +517,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -517,7 +517,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -517,7 +517,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -517,7 +517,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -532,7 +532,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -534,7 +534,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -534,7 +534,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -534,7 +534,9 @@ final class Php83Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -534,7 +534,9 @@ final class Php84Test extends ExplicitRuleSetTestCase
                     'assertSame',
                 ],
             ],
-            'php_unit_data_provider_method_order' => false,
+            'php_unit_data_provider_method_order' => [
+                'placement' => 'after',
+            ],
             'php_unit_data_provider_name' => false,
             'php_unit_data_provider_return_type' => true,
             'php_unit_data_provider_static' => [


### PR DESCRIPTION
This pull request

- [x] enables and configures the `php_unit_data_provider_method_order` fixer

Follows #1177.