### PR TITLE
Enhancement: Enable `PhpCsFixerCustomFixers/php_unit_requires_constraint` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.45.0...main`][6.45.0...main].
 ### Changed
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1193]), by [@dependabot]
+- Enabled the `PhpCsFixerCustomFixers/php_unit_requires_constraint` fixer ([#1200]), by [@localheinz]
 
 ## [`6.45.0`][6.45.0]
 
@@ -1919,6 +1920,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1183]: https://github.com/ergebnis/php-cs-fixer-config/pull/1183
 [#1187]: https://github.com/ergebnis/php-cs-fixer-config/pull/1187
 [#1193]: https://github.com/ergebnis/php-cs-fixer-config/pull/1193
+[#1200]: https://github.com/ergebnis/php-cs-fixer-config/pull/1200
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -37,6 +37,7 @@ final class Php53
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php53
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -37,6 +37,7 @@ final class Php54
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php54
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -37,6 +37,7 @@ final class Php55
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php55
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -37,6 +37,7 @@ final class Php56
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php56
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -37,6 +37,7 @@ final class Php70
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php70
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -37,6 +37,7 @@ final class Php71
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php71
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -37,6 +37,7 @@ final class Php72
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php72
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -37,6 +37,7 @@ final class Php73
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php73
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -37,6 +37,7 @@ final class Php74
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -52,6 +53,7 @@ final class Php74
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -38,6 +38,7 @@ final class Php80
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php80
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -38,6 +38,7 @@ final class Php81
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php81
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -38,6 +38,7 @@ final class Php82
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php82
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -38,6 +38,7 @@ final class Php83
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php83
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -38,6 +38,7 @@ final class Php84
                 new Fixer\NoDuplicatedArrayKeyFixer(),
                 new Fixer\NoDuplicatedImportsFixer(),
                 new Fixer\PhpdocTypesCommaSpacesFixer(),
+                new Fixer\PhpUnitRequiresConstraintFixer(),
                 new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
             ),
             Name::fromString(\sprintf(
@@ -57,6 +58,7 @@ final class Php84
                     'ignore_expressions' => true,
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+                'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [
                     'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -48,6 +48,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -48,6 +48,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -43,6 +43,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -48,6 +48,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -48,6 +48,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -48,6 +48,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -48,6 +48,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -48,6 +48,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -48,6 +48,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -75,6 +76,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -49,6 +49,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -49,6 +49,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -49,6 +49,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -49,6 +49,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -49,6 +49,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
             new Fixer\NoDuplicatedArrayKeyFixer(),
             new Fixer\NoDuplicatedImportsFixer(),
             new Fixer\PhpdocTypesCommaSpacesFixer(),
+            new Fixer\PhpUnitRequiresConstraintFixer(),
             new PhpCsFixer\Fixer\Whitespace\LineBreakAfterStatementsFixer(),
         );
     }
@@ -80,6 +81,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
                 'ignore_expressions' => true,
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
+            'PhpCsFixerCustomFixers/php_unit_requires_constraint' => true,
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [
                 'comment_type' => 'all_multiline',


### PR DESCRIPTION
This pull request

- [x] enables the `PhpCsFixerCustomFixers/php_unit_requires_constraint` fixer

Follows https://github.com/ergebnis/php-cs-fixer-config/pull/1193.