### PR TITLE
Enhancement: Add `as`, `else`, and `elseif` to `constructs_preceded_by_a_single_space` option of `single_space_around_construct` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`6.46.0...main`][6.46.0...main].
 
+### Changed
+
+- Added `as`, `else`, and `elseif` to `constructs_preceded_by_a_single_space` option of `single_space_around_construct` fixer ([#1212]), by [@localheinz]
+
 ## [`6.46.0`][6.46.0]
 
 For a full diff see [`6.45.0...6.46.0`][6.45.0...6.46.0].
@@ -1929,6 +1933,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1193]: https://github.com/ergebnis/php-cs-fixer-config/pull/1193
 [#1199]: https://github.com/ergebnis/php-cs-fixer-config/pull/1199
 [#1200]: https://github.com/ergebnis/php-cs-fixer-config/pull/1200
+[#1212]: https://github.com/ergebnis/php-cs-fixer-config/pull/1212
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -801,6 +801,9 @@ final class Php53
                         'while',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -803,6 +803,9 @@ final class Php54
                         'while',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -814,6 +814,9 @@ final class Php55
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -814,6 +814,9 @@ final class Php56
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -816,6 +816,9 @@ final class Php70
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -816,6 +816,9 @@ final class Php71
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -816,6 +816,9 @@ final class Php72
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -816,6 +816,9 @@ final class Php73
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -820,6 +820,9 @@ final class Php74
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -839,6 +839,9 @@ final class Php80
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -842,6 +842,9 @@ final class Php81
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -842,6 +842,9 @@ final class Php82
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -842,6 +842,9 @@ final class Php83
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -842,6 +842,9 @@ final class Php84
                         'yield_from',
                     ],
                     'constructs_preceded_by_a_single_space' => [
+                        'as',
+                        'else',
+                        'elseif',
                         'use_lambda',
                     ],
                 ],

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -824,6 +824,9 @@ final class Php53Test extends ExplicitRuleSetTestCase
                     'while',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -826,6 +826,9 @@ final class Php54Test extends ExplicitRuleSetTestCase
                     'while',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -837,6 +837,9 @@ final class Php55Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -837,6 +837,9 @@ final class Php56Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -839,6 +839,9 @@ final class Php70Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -839,6 +839,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -839,6 +839,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -839,6 +839,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -843,6 +843,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -862,6 +862,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -865,6 +865,9 @@ final class Php81Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -865,6 +865,9 @@ final class Php82Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -865,6 +865,9 @@ final class Php83Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -865,6 +865,9 @@ final class Php84Test extends ExplicitRuleSetTestCase
                     'yield_from',
                 ],
                 'constructs_preceded_by_a_single_space' => [
+                    'as',
+                    'else',
+                    'elseif',
                     'use_lambda',
                 ],
             ],


### PR DESCRIPTION

This pull request

- [x] adds `as`, `else`, and `elseif` to the  `constructs_preceded_by_a_single_space` option of `single_space_around_construct` fixer

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.75.0/doc/rules/language_construct/single_space_around_construct.rst.