### PR TITLE
Enhancement: Enable and configure `new_expression_parentheses` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`6.46.0...main`][6.46.0...main].
 - Updated `friendsofphp/php-cs-fixer` ([#1235]), by [@dependabot]
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1235]), by [@localheinz]
 - Configured the `multiline_promoted_properties` instead of the deprecated `PhpCsFixerCustomFixers/multiline_promoted_properties` fixer ([#1235]), by [@localheinz]
+- Enabled and configured the `new_expression_parentheses` fixer  ([#1236]), by [@localheinz]
 
 ## [`6.46.0`][6.46.0]
 
@@ -1946,6 +1947,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1232]: https://github.com/ergebnis/php-cs-fixer-config/pull/1232
 [#1233]: https://github.com/ergebnis/php-cs-fixer-config/pull/1233
 [#1235]: https://github.com/ergebnis/php-cs-fixer-config/pull/1235
+[#1236]: https://github.com/ergebnis/php-cs-fixer-config/pull/1236
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -336,7 +336,9 @@ final class Php84
                     'strict' => false,
                 ],
                 'native_type_declaration_casing' => true,
-                'new_expression_parentheses' => false,
+                'new_expression_parentheses' => [
+                    'use_parentheses' => true,
+                ],
                 'new_with_parentheses' => [
                     'anonymous_class' => true,
                     'named_class' => true,

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -358,7 +358,9 @@ final class Php84Test extends ExplicitRuleSetTestCase
                 'strict' => false,
             ],
             'native_type_declaration_casing' => true,
-            'new_expression_parentheses' => false,
+            'new_expression_parentheses' => [
+                'use_parentheses' => true,
+            ],
             'new_with_parentheses' => [
                 'anonymous_class' => true,
                 'named_class' => true,


### PR DESCRIPTION
This pull request

- [x] enables and configures the `new_expression_parentheses` fixer

Follows #1235

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.76.0/doc/rules/operator/new_expression_parentheses.rst,