### PR TITLE
Enhancement: Enable `static_private_method` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a full diff see [`6.46.0...main`][6.46.0...main].
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1235]), by [@localheinz]
 - Configured the `multiline_promoted_properties` instead of the deprecated `PhpCsFixerCustomFixers/multiline_promoted_properties` fixer ([#1235]), by [@localheinz]
 - Enabled and configured the `new_expression_parentheses` fixer  ([#1236]), by [@localheinz]
+- Enabled the `static_private_method` fixer  ([#1237]), by [@localheinz]
 
 ## [`6.46.0`][6.46.0]
 
@@ -1948,6 +1949,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1233]: https://github.com/ergebnis/php-cs-fixer-config/pull/1233
 [#1235]: https://github.com/ergebnis/php-cs-fixer-config/pull/1235
 [#1236]: https://github.com/ergebnis/php-cs-fixer-config/pull/1236
+[#1237]: https://github.com/ergebnis/php-cs-fixer-config/pull/1237
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -830,7 +830,7 @@ final class Php53
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -832,7 +832,7 @@ final class Php54
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -843,7 +843,7 @@ final class Php55
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -843,7 +843,7 @@ final class Php56
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -845,7 +845,7 @@ final class Php70
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -845,7 +845,7 @@ final class Php71
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -845,7 +845,7 @@ final class Php72
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -845,7 +845,7 @@ final class Php73
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -849,7 +849,7 @@ final class Php74
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -866,7 +866,7 @@ final class Php80
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -869,7 +869,7 @@ final class Php81
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -869,7 +869,7 @@ final class Php82
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -871,7 +871,7 @@ final class Php83
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -873,7 +873,7 @@ final class Php84
                     'stick_comment_to_next_continuous_control_statement' => false,
                 ],
                 'static_lambda' => true,
-                'static_private_method' => false,
+                'static_private_method' => true,
                 'strict_comparison' => true,
                 'strict_param' => true,
                 'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -852,7 +852,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -854,7 +854,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -865,7 +865,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -865,7 +865,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -867,7 +867,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -867,7 +867,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -867,7 +867,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -867,7 +867,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -871,7 +871,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -888,7 +888,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -891,7 +891,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -891,7 +891,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -893,7 +893,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -895,7 +895,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
                 'stick_comment_to_next_continuous_control_statement' => false,
             ],
             'static_lambda' => true,
-            'static_private_method' => false,
+            'static_private_method' => true,
             'strict_comparison' => true,
             'strict_param' => true,
             'string_implicit_backslashes' => [


### PR DESCRIPTION
This pull request

- [x] enables the `static_private_method` fixer

Follows #1235.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.76.0/doc/rules/class_notation/static_private_method.rst.