### PR TITLE
Fix: Stop using deprecated `use_trait` token for `tokens` option of `no_extra_blank_lines` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`6.47.0...main`][6.47.0...main].
 ### Fixed
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1241]), by [@dependabot]
+- Stopped using deprecated `use_trait` token for for `tokens` option of `no_extra_blank_lines` fixer ([#1243]), by [@localheinz]
 
 ## [`6.47.0`][6.47.0]
 
@@ -1970,6 +1971,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1239]: https://github.com/ergebnis/php-cs-fixer-config/pull/1239
 [#1240]: https://github.com/ergebnis/php-cs-fixer-config/pull/1240
 [#1241]: https://github.com/ergebnis/php-cs-fixer-config/pull/1241
+[#1243]: https://github.com/ergebnis/php-cs-fixer-config/pull/1243
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -361,7 +361,6 @@ final class Php54
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -365,7 +365,6 @@ final class Php55
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -365,7 +365,6 @@ final class Php56
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -365,7 +365,6 @@ final class Php70
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -365,7 +365,6 @@ final class Php71
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -365,7 +365,6 @@ final class Php72
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -365,7 +365,6 @@ final class Php73
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -365,7 +365,6 @@ final class Php74
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -373,7 +373,6 @@ final class Php80
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -374,7 +374,6 @@ final class Php81
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -374,7 +374,6 @@ final class Php82
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -376,7 +376,6 @@ final class Php83
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -378,7 +378,6 @@ final class Php84
                         'switch',
                         'throw',
                         'use',
-                        'use_trait',
                     ],
                 ],
                 'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -383,7 +383,6 @@ final class Php54Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -387,7 +387,6 @@ final class Php55Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -387,7 +387,6 @@ final class Php56Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -387,7 +387,6 @@ final class Php70Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -387,7 +387,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -387,7 +387,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -387,7 +387,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -387,7 +387,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -395,7 +395,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -396,7 +396,6 @@ final class Php81Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -396,7 +396,6 @@ final class Php82Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -398,7 +398,6 @@ final class Php83Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -400,7 +400,6 @@ final class Php84Test extends ExplicitRuleSetTestCase
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_homoglyph_names' => true,


### PR DESCRIPTION
This pull request

- [x] stops using the deprecated `use_trait` token for `tokens` option of `no_extra_blank_lines` fixer

Follows #1239.