### PR TITLE
Enhancement: Enable `no_useless_printf` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.49.0...main`][6.49.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#1249]), by [@dependabot]
+- Enabled the `no_useless_printf` fixer ([#1252]), by [@localheinz]
 
 ### Fixed
 
@@ -1999,7 +2000,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1244]: https://github.com/ergebnis/php-cs-fixer-config/pull/1244
 [#1245]: https://github.com/ergebnis/php-cs-fixer-config/pull/1245
 [#1249]: https://github.com/ergebnis/php-cs-fixer-config/pull/1249
-[#1251]: https://github.com/ergebnis/php-cs-fixer-config/pull/1251
+[#1252]: https://github.com/ergebnis/php-cs-fixer-config/pull/1252
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -423,7 +423,7 @@ final class Php53
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -424,7 +424,7 @@ final class Php54
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -430,7 +430,7 @@ final class Php55
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -430,7 +430,7 @@ final class Php56
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -430,7 +430,7 @@ final class Php70
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -430,7 +430,7 @@ final class Php71
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -430,7 +430,7 @@ final class Php72
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -430,7 +430,7 @@ final class Php73
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -430,7 +430,7 @@ final class Php74
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => false,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -438,7 +438,7 @@ final class Php80
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => true,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -439,7 +439,7 @@ final class Php81
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => true,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -439,7 +439,7 @@ final class Php82
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => true,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -441,7 +441,7 @@ final class Php83
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => true,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -443,7 +443,7 @@ final class Php84
                 ],
                 'no_useless_else' => true,
                 'no_useless_nullsafe_operator' => true,
-                'no_useless_printf' => false,
+                'no_useless_printf' => true,
                 'no_useless_return' => true,
                 'no_useless_sprintf' => true,
                 'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -445,7 +445,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -446,7 +446,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -452,7 +452,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -452,7 +452,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -452,7 +452,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -452,7 +452,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -452,7 +452,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -452,7 +452,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -452,7 +452,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => false,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -460,7 +460,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => true,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -461,7 +461,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => true,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -461,7 +461,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => true,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -463,7 +463,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => true,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -465,7 +465,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
             ],
             'no_useless_else' => true,
             'no_useless_nullsafe_operator' => true,
-            'no_useless_printf' => false,
+            'no_useless_printf' => true,
             'no_useless_return' => true,
             'no_useless_sprintf' => true,
             'no_whitespace_before_comma_in_array' => [


### PR DESCRIPTION
This pull request

- [x] enables the `no_useless_printf` fixer

Follows #1249.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.84.0/doc/rules/function_notation/no_useless_printf.rst.