### PR TITLE
Enhancement: Enable and configure `ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,13 @@ return static function (Config\RectorConfig $rectorConfig): void {
         Rules\Faker\GeneratorPropertyFetchToMethodCallRector::class,
     ]);
 
+    $rectorConfig->ruleWithConfiguration(Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector::class, [
+        'discoverNamespacePrefixes' => true,
+        'parentNamespacePrefixes' => [
+            'Symfony\Component',
+        ],
+    ]);
+
     $rectorConfig->sets([
         PHPUnit\Set\PHPUnitSetList::PHPUNIT_90,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/php-cs-fixer-config
  */
 
-use Ergebnis\Rector\Rules;
+use Ergebnis\Rector;
 use Rector\Config;
 use Rector\PHPUnit;
 use Rector\ValueObject;
@@ -29,11 +29,11 @@ return static function (Config\RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(ValueObject\PhpVersion::PHP_74);
 
     $rectorConfig->rules([
-        Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class,
-        Rules\Faker\GeneratorPropertyFetchToMethodCallRector::class,
+        Rector\Rules\Expressions\Arrays\SortAssociativeArrayByKeyRector::class,
+        Rector\Rules\Faker\GeneratorPropertyFetchToMethodCallRector::class,
     ]);
 
-    $rectorConfig->ruleWithConfiguration(Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector::class, [
+    $rectorConfig->ruleWithConfiguration(Rector\Rules\Files\ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector::class, [
         'discoverNamespacePrefixes' => true,
         'parentNamespacePrefixes' => [
             'Symfony\Component',

--- a/test/Unit/FactoryTest.php
+++ b/test/Unit/FactoryTest.php
@@ -13,13 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
-use Ergebnis\PhpCsFixer\Config\Factory;
-use Ergebnis\PhpCsFixer\Config\Fixers;
-use Ergebnis\PhpCsFixer\Config\Name;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
-use Ergebnis\PhpCsFixer\Config\Rules;
-use Ergebnis\PhpCsFixer\Config\RuleSet;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PhpCsFixer\Fixer;
 use PhpCsFixer\Runner;
 use PHPUnit\Framework;
@@ -40,59 +34,59 @@ use PHPUnit\Framework;
  */
 final class FactoryTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     public function testFromRuleSetThrowsRuntimeExceptionWhenCurrentPhpVersionIsLessThanTargetPhpVersion(): void
     {
-        $phpVersion = PhpVersion::create(
-            PhpVersion\Major::fromInt(\PHP_MAJOR_VERSION),
-            PhpVersion\Minor::fromInt(\PHP_MINOR_VERSION),
-            PhpVersion\Patch::fromInt(\PHP_RELEASE_VERSION + 1),
+        $phpVersion = PhpCsFixer\Config\PhpVersion::create(
+            PhpCsFixer\Config\PhpVersion\Major::fromInt(\PHP_MAJOR_VERSION),
+            PhpCsFixer\Config\PhpVersion\Minor::fromInt(\PHP_MINOR_VERSION),
+            PhpCsFixer\Config\PhpVersion\Patch::fromInt(\PHP_RELEASE_VERSION + 1),
         );
 
-        $ruleSet = RuleSet::create(
-            Fixers::empty(),
-            Name::fromString(self::faker()->word()),
+        $ruleSet = PhpCsFixer\Config\RuleSet::create(
+            PhpCsFixer\Config\Fixers::empty(),
+            PhpCsFixer\Config\Name::fromString(self::faker()->word()),
             $phpVersion,
-            Rules::fromArray([]),
+            PhpCsFixer\Config\Rules::fromArray([]),
         );
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf(
             'Current PHP version "%s" is smaller than targeted PHP version "%s".',
-            PhpVersion::current()->toString(),
+            PhpCsFixer\Config\PhpVersion::current()->toString(),
             $phpVersion->toString(),
         ));
 
-        Factory::fromRuleSet($ruleSet);
+        PhpCsFixer\Config\Factory::fromRuleSet($ruleSet);
     }
 
     /**
      * @dataProvider provideTargetPhpVersionLessThanOrEqualToCurrentPhpVersion
      */
-    public function testFromRuleSetCreatesConfigWhenCurrentPhpVersionIsEqualToOrGreaterThanTargetPhpVersion(PhpVersion $targetPhpVersion): void
+    public function testFromRuleSetCreatesConfigWhenCurrentPhpVersionIsEqualToOrGreaterThanTargetPhpVersion(PhpCsFixer\Config\PhpVersion $targetPhpVersion): void
     {
-        $customFixers = Fixers::fromFixers(
+        $customFixers = PhpCsFixer\Config\Fixers::fromFixers(
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
         );
 
-        $rules = Rules::fromArray([
+        $rules = PhpCsFixer\Config\Rules::fromArray([
             'bar' => [
                 'baz' => true,
             ],
             'foo' => true,
         ]);
 
-        $ruleSet = RuleSet::create(
+        $ruleSet = PhpCsFixer\Config\RuleSet::create(
             $customFixers,
-            Name::fromString(self::faker()->word()),
+            PhpCsFixer\Config\Name::fromString(self::faker()->word()),
             $targetPhpVersion,
             $rules,
         );
 
-        $config = Factory::fromRuleSet($ruleSet);
+        $config = PhpCsFixer\Config\Factory::fromRuleSet($ruleSet);
 
         self::assertEquals($customFixers->toArray(), $config->getCustomFixers());
         self::assertEquals(Runner\Parallel\ParallelConfigFactory::detect(), $config->getParallelConfig());
@@ -102,13 +96,13 @@ final class FactoryTest extends Framework\TestCase
     }
 
     /**
-     * @return \Generator<int, array{0: PhpVersion}>
+     * @return \Generator<int, array{0: PhpCsFixer\Config\PhpVersion}>
      */
     public static function provideTargetPhpVersionLessThanOrEqualToCurrentPhpVersion(): iterable
     {
         $values = [
-            PhpVersion::fromInt(\PHP_VERSION_ID - 1),
-            PhpVersion::fromInt(\PHP_VERSION_ID),
+            PhpCsFixer\Config\PhpVersion::fromInt(\PHP_VERSION_ID - 1),
+            PhpCsFixer\Config\PhpVersion::fromInt(\PHP_VERSION_ID),
         ];
 
         foreach ($values as $value) {

--- a/test/Unit/FixersTest.php
+++ b/test/Unit/FixersTest.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
-use Ergebnis\PhpCsFixer\Config\Fixers;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PhpCsFixer\Fixer;
 use PHPUnit\Framework;
 
@@ -25,11 +24,11 @@ use PHPUnit\Framework;
  */
 final class FixersTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     public function testEmptyReturnsFixers(): void
     {
-        $fixers = Fixers::empty();
+        $fixers = PhpCsFixer\Config\Fixers::empty();
 
         self::assertSame([], $fixers->toArray());
     }
@@ -42,7 +41,7 @@ final class FixersTest extends Framework\TestCase
             $this->createStub(Fixer\FixerInterface::class),
         ];
 
-        $fixers = Fixers::fromFixers(...$value);
+        $fixers = PhpCsFixer\Config\Fixers::fromFixers(...$value);
 
         self::assertSame($value, $fixers->toArray());
     }
@@ -57,7 +56,7 @@ final class FixersTest extends Framework\TestCase
             \Traversable::class,
         ));
 
-        Fixers::fromIterable($iterable);
+        PhpCsFixer\Config\Fixers::fromIterable($iterable);
     }
 
     public function testFromIterableRejectsIterableWhenItIsNotATraversable(): void
@@ -71,7 +70,7 @@ final class FixersTest extends Framework\TestCase
             \stdClass::class,
         ));
 
-        Fixers::fromIterable($iterable);
+        PhpCsFixer\Config\Fixers::fromIterable($iterable);
     }
 
     public function testFromIterableRejectsIterableWhenItDoesNotContainFixersOnly(): void
@@ -89,7 +88,7 @@ final class FixersTest extends Framework\TestCase
             \stdClass::class,
         ));
 
-        Fixers::fromIterable($iterable);
+        PhpCsFixer\Config\Fixers::fromIterable($iterable);
     }
 
     public function testFromIterableReturnsFixersWhenValueIsArray(): void
@@ -100,7 +99,7 @@ final class FixersTest extends Framework\TestCase
             $this->createStub(Fixer\FixerInterface::class),
         ];
 
-        $fixers = Fixers::fromIterable($value);
+        $fixers = PhpCsFixer\Config\Fixers::fromIterable($value);
 
         self::assertSame($value, $fixers->toArray());
     }
@@ -115,20 +114,20 @@ final class FixersTest extends Framework\TestCase
 
         $iterable = new \ArrayIterator($value);
 
-        $fixers = Fixers::fromIterable($iterable);
+        $fixers = PhpCsFixer\Config\Fixers::fromIterable($iterable);
 
         self::assertSame($value, $fixers->toArray());
     }
 
     public function testMergeReturnsFixersMergedWithFixers(): void
     {
-        $one = Fixers::fromFixers(
+        $one = PhpCsFixer\Config\Fixers::fromFixers(
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
         );
 
-        $two = Fixers::fromFixers(
+        $two = PhpCsFixer\Config\Fixers::fromFixers(
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
         );
@@ -138,7 +137,7 @@ final class FixersTest extends Framework\TestCase
         self::assertNotSame($one, $mutated);
         self::assertNotSame($two, $mutated);
 
-        $expected = Fixers::fromFixers(...\array_merge(
+        $expected = PhpCsFixer\Config\Fixers::fromFixers(...\array_merge(
             $one->toArray(),
             $two->toArray(),
         ));

--- a/test/Unit/NameTest.php
+++ b/test/Unit/NameTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
 use Ergebnis\DataProvider;
-use Ergebnis\PhpCsFixer\Config\Name;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PHPUnit\Framework;
 
 /**
@@ -30,7 +29,7 @@ use PHPUnit\Framework;
  */
 final class NameTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     /**
      * @dataProvider \Ergebnis\DataProvider\StringProvider::blank
@@ -41,14 +40,14 @@ final class NameTest extends Framework\TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Value can not be blank or empty.');
 
-        Name::fromString($value);
+        PhpCsFixer\Config\Name::fromString($value);
     }
 
     public function testFromStringReturnsName(): void
     {
         $value = self::faker()->word();
 
-        $name = Name::fromString($value);
+        $name = PhpCsFixer\Config\Name::fromString($value);
 
         self::assertSame($value, $name->toString());
     }

--- a/test/Unit/PhpVersion/MajorTest.php
+++ b/test/Unit/PhpVersion/MajorTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\PhpVersion;
 
 use Ergebnis\DataProvider;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
+use Ergebnis\PhpCsFixer;
 use PHPUnit\Framework;
 
 /**
@@ -35,7 +35,7 @@ final class MajorTest extends Framework\TestCase
             $value,
         ));
 
-        PhpVersion\Major::fromInt($value);
+        PhpCsFixer\Config\PhpVersion\Major::fromInt($value);
     }
 
     /**
@@ -44,7 +44,7 @@ final class MajorTest extends Framework\TestCase
      */
     public function testFromIntReturnsMajor(int $value): void
     {
-        $major = PhpVersion\Major::fromInt($value);
+        $major = PhpCsFixer\Config\PhpVersion\Major::fromInt($value);
 
         self::assertSame($value, $major->toInt());
     }

--- a/test/Unit/PhpVersion/MinorTest.php
+++ b/test/Unit/PhpVersion/MinorTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\PhpVersion;
 
 use Ergebnis\DataProvider;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PHPUnit\Framework;
 
 /**
@@ -25,7 +24,7 @@ use PHPUnit\Framework;
  */
 final class MinorTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     /**
      * @dataProvider \Ergebnis\DataProvider\IntProvider::lessThanZero
@@ -38,7 +37,7 @@ final class MinorTest extends Framework\TestCase
             $value,
         ));
 
-        PhpVersion\Minor::fromInt($value);
+        PhpCsFixer\Config\PhpVersion\Minor::fromInt($value);
     }
 
     /**
@@ -52,7 +51,7 @@ final class MinorTest extends Framework\TestCase
             $value,
         ));
 
-        PhpVersion\Minor::fromInt($value);
+        PhpCsFixer\Config\PhpVersion\Minor::fromInt($value);
     }
 
     /**
@@ -77,7 +76,7 @@ final class MinorTest extends Framework\TestCase
      */
     public function testFromIntReturnsMinor(int $value): void
     {
-        $minor = PhpVersion\Minor::fromInt($value);
+        $minor = PhpCsFixer\Config\PhpVersion\Minor::fromInt($value);
 
         self::assertSame($value, $minor->toInt());
     }

--- a/test/Unit/PhpVersion/PatchTest.php
+++ b/test/Unit/PhpVersion/PatchTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\PhpVersion;
 
 use Ergebnis\DataProvider;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PHPUnit\Framework;
 
 /**
@@ -25,7 +24,7 @@ use PHPUnit\Framework;
  */
 final class PatchTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     /**
      * @dataProvider \Ergebnis\DataProvider\IntProvider::lessThanZero
@@ -38,7 +37,7 @@ final class PatchTest extends Framework\TestCase
             $value,
         ));
 
-        PhpVersion\Patch::fromInt($value);
+        PhpCsFixer\Config\PhpVersion\Patch::fromInt($value);
     }
 
     /**
@@ -52,7 +51,7 @@ final class PatchTest extends Framework\TestCase
             $value,
         ));
 
-        PhpVersion\Patch::fromInt($value);
+        PhpCsFixer\Config\PhpVersion\Patch::fromInt($value);
     }
 
     /**
@@ -77,7 +76,7 @@ final class PatchTest extends Framework\TestCase
      */
     public function testFromIntReturnsPatch(int $value): void
     {
-        $patch = PhpVersion\Patch::fromInt($value);
+        $patch = PhpCsFixer\Config\PhpVersion\Patch::fromInt($value);
 
         self::assertSame($value, $patch->toInt());
     }

--- a/test/Unit/PhpVersionTest.php
+++ b/test/Unit/PhpVersionTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
 use Ergebnis\DataProvider;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PHPUnit\Framework;
 
 /**
@@ -29,17 +28,17 @@ use PHPUnit\Framework;
  */
 final class PhpVersionTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     public function testCreateReturnsPhpVersion(): void
     {
         $faker = self::faker();
 
-        $major = PhpVersion\Major::fromInt($faker->numberBetween(0));
-        $minor = PhpVersion\Minor::fromInt($faker->numberBetween(0, 99));
-        $patch = PhpVersion\Patch::fromInt($faker->numberBetween(0, 99));
+        $major = PhpCsFixer\Config\PhpVersion\Major::fromInt($faker->numberBetween(0));
+        $minor = PhpCsFixer\Config\PhpVersion\Minor::fromInt($faker->numberBetween(0, 99));
+        $patch = PhpCsFixer\Config\PhpVersion\Patch::fromInt($faker->numberBetween(0, 99));
 
-        $phpVersion = PhpVersion::create(
+        $phpVersion = PhpCsFixer\Config\PhpVersion::create(
             $major,
             $minor,
             $patch,
@@ -70,7 +69,7 @@ final class PhpVersionTest extends Framework\TestCase
             $value,
         ));
 
-        PhpVersion::fromInt($value);
+        PhpCsFixer\Config\PhpVersion::fromInt($value);
     }
 
     /**
@@ -79,22 +78,22 @@ final class PhpVersionTest extends Framework\TestCase
      */
     public function testFromIntReturnsPhpVersion(int $value): void
     {
-        $phpVersion = PhpVersion::fromInt($value);
+        $phpVersion = PhpCsFixer\Config\PhpVersion::fromInt($value);
 
         self::assertSame($value, $phpVersion->toInt());
     }
 
     public function testCurrentReturnsPhpVersion(): void
     {
-        $phpVersion = PhpVersion::current();
+        $phpVersion = PhpCsFixer\Config\PhpVersion::current();
 
         self::assertSame(\PHP_VERSION_ID, $phpVersion->toInt());
     }
 
     public function testIsSmallerThanReturnsFalseWhenValueIsGreater(): void
     {
-        $one = PhpVersion::fromInt(\PHP_VERSION_ID + 1);
-        $two = PhpVersion::fromInt(\PHP_VERSION_ID);
+        $one = PhpCsFixer\Config\PhpVersion::fromInt(\PHP_VERSION_ID + 1);
+        $two = PhpCsFixer\Config\PhpVersion::fromInt(\PHP_VERSION_ID);
 
         self::assertFalse($one->isSmallerThan($two));
     }
@@ -103,16 +102,16 @@ final class PhpVersionTest extends Framework\TestCase
     {
         $value = \PHP_VERSION_ID;
 
-        $one = PhpVersion::fromInt($value);
-        $two = PhpVersion::fromInt($value);
+        $one = PhpCsFixer\Config\PhpVersion::fromInt($value);
+        $two = PhpCsFixer\Config\PhpVersion::fromInt($value);
 
         self::assertFalse($one->isSmallerThan($two));
     }
 
     public function testIsSmallerThanReturnsTrueWhenValueIsSmaller(): void
     {
-        $one = PhpVersion::fromInt(\PHP_VERSION_ID);
-        $two = PhpVersion::fromInt(\PHP_VERSION_ID + 1);
+        $one = PhpCsFixer\Config\PhpVersion::fromInt(\PHP_VERSION_ID);
+        $two = PhpCsFixer\Config\PhpVersion::fromInt(\PHP_VERSION_ID + 1);
 
         self::assertTrue($one->isSmallerThan($two));
     }

--- a/test/Unit/RuleSet/AbstractRuleSetTestCase.php
+++ b/test/Unit/RuleSet/AbstractRuleSetTestCase.php
@@ -13,11 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit\RuleSet;
 
-use Ergebnis\PhpCsFixer\Config\Fixers;
-use Ergebnis\PhpCsFixer\Config\Name;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
-use Ergebnis\PhpCsFixer\Config\Rules;
-use Ergebnis\PhpCsFixer\Config\RuleSet;
+use Ergebnis\PhpCsFixer;
 use PhpCsFixer\Fixer;
 use PhpCsFixer\FixerConfiguration;
 use PhpCsFixer\FixerFactory;
@@ -183,18 +179,18 @@ abstract class AbstractRuleSetTestCase extends Framework\TestCase
         self::assertFalse($rules->toArray()['header_comment']);
     }
 
-    abstract protected function expectedCustomFixers(): Fixers;
+    abstract protected function expectedCustomFixers(): PhpCsFixer\Config\Fixers;
 
-    abstract protected function expectedName(): Name;
+    abstract protected function expectedName(): PhpCsFixer\Config\Name;
 
-    abstract protected function expectedPhpVersion(): PhpVersion;
+    abstract protected function expectedPhpVersion(): PhpCsFixer\Config\PhpVersion;
 
-    abstract protected function expectedRules(): Rules;
+    abstract protected function expectedRules(): PhpCsFixer\Config\Rules;
 
     /**
      * @throws \RuntimeException
      */
-    abstract protected static function createRuleSet(): RuleSet;
+    abstract protected static function createRuleSet(): PhpCsFixer\Config\RuleSet;
 
     /**
      * @return array<string, Fixer\FixerInterface>

--- a/test/Unit/RuleSetTest.php
+++ b/test/Unit/RuleSetTest.php
@@ -13,12 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
-use Ergebnis\PhpCsFixer\Config\Fixers;
-use Ergebnis\PhpCsFixer\Config\Name;
-use Ergebnis\PhpCsFixer\Config\PhpVersion;
-use Ergebnis\PhpCsFixer\Config\Rules;
-use Ergebnis\PhpCsFixer\Config\RuleSet;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PhpCsFixer\Fixer;
 use PHPUnit\Framework;
 
@@ -37,28 +32,28 @@ use PHPUnit\Framework;
  */
 final class RuleSetTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     public function testCreateReturnsRuleSet(): void
     {
         $faker = self::faker();
 
-        $customFixers = Fixers::fromFixers(
+        $customFixers = PhpCsFixer\Config\Fixers::fromFixers(
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
         );
-        $name = Name::fromString($faker->word());
-        $phpVersion = PhpVersion::create(
-            PhpVersion\Major::fromInt($faker->numberBetween(0)),
-            PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
-            PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
+        $name = PhpCsFixer\Config\Name::fromString($faker->word());
+        $phpVersion = PhpCsFixer\Config\PhpVersion::create(
+            PhpCsFixer\Config\PhpVersion\Major::fromInt($faker->numberBetween(0)),
+            PhpCsFixer\Config\PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
+            PhpCsFixer\Config\PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
         );
-        $rules = Rules::fromArray([
+        $rules = PhpCsFixer\Config\Rules::fromArray([
             'header_comment' => false,
         ]);
 
-        $ruleSet = RuleSet::create(
+        $ruleSet = PhpCsFixer\Config\RuleSet::create(
             $customFixers,
             $name,
             $phpVersion,
@@ -75,24 +70,24 @@ final class RuleSetTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $customFixers = Fixers::fromFixers(
+        $customFixers = PhpCsFixer\Config\Fixers::fromFixers(
             $this->createStub(Fixer\FixerInterface::class),
             $this->createStub(Fixer\FixerInterface::class),
         );
 
-        $ruleSet = RuleSet::create(
-            Fixers::fromFixers(
+        $ruleSet = PhpCsFixer\Config\RuleSet::create(
+            PhpCsFixer\Config\Fixers::fromFixers(
                 $this->createStub(Fixer\FixerInterface::class),
                 $this->createStub(Fixer\FixerInterface::class),
                 $this->createStub(Fixer\FixerInterface::class),
             ),
-            Name::fromString($faker->word()),
-            PhpVersion::create(
-                PhpVersion\Major::fromInt($faker->numberBetween(0)),
-                PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
-                PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
+            PhpCsFixer\Config\Name::fromString($faker->word()),
+            PhpCsFixer\Config\PhpVersion::create(
+                PhpCsFixer\Config\PhpVersion\Major::fromInt($faker->numberBetween(0)),
+                PhpCsFixer\Config\PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
+                PhpCsFixer\Config\PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
             ),
-            Rules::fromArray([
+            PhpCsFixer\Config\Rules::fromArray([
                 'foo' => false,
                 'quz' => true,
             ]),
@@ -114,24 +109,24 @@ final class RuleSetTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $rules = Rules::fromArray([
+        $rules = PhpCsFixer\Config\Rules::fromArray([
             'bar' => false,
             'foo' => true,
         ]);
 
-        $ruleSet = RuleSet::create(
-            Fixers::fromFixers(
+        $ruleSet = PhpCsFixer\Config\RuleSet::create(
+            PhpCsFixer\Config\Fixers::fromFixers(
                 $this->createStub(Fixer\FixerInterface::class),
                 $this->createStub(Fixer\FixerInterface::class),
                 $this->createStub(Fixer\FixerInterface::class),
             ),
-            Name::fromString($faker->word()),
-            PhpVersion::create(
-                PhpVersion\Major::fromInt($faker->numberBetween(0)),
-                PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
-                PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
+            PhpCsFixer\Config\Name::fromString($faker->word()),
+            PhpCsFixer\Config\PhpVersion::create(
+                PhpCsFixer\Config\PhpVersion\Major::fromInt($faker->numberBetween(0)),
+                PhpCsFixer\Config\PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
+                PhpCsFixer\Config\PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
             ),
-            Rules::fromArray([
+            PhpCsFixer\Config\Rules::fromArray([
                 'foo' => false,
                 'quz' => true,
             ]),
@@ -157,19 +152,19 @@ final class RuleSetTest extends Framework\TestCase
     {
         $faker = self::faker();
 
-        $ruleSet = RuleSet::create(
-            Fixers::fromFixers(
+        $ruleSet = PhpCsFixer\Config\RuleSet::create(
+            PhpCsFixer\Config\Fixers::fromFixers(
                 $this->createStub(Fixer\FixerInterface::class),
                 $this->createStub(Fixer\FixerInterface::class),
                 $this->createStub(Fixer\FixerInterface::class),
             ),
-            Name::fromString($faker->word()),
-            PhpVersion::create(
-                PhpVersion\Major::fromInt($faker->numberBetween(0)),
-                PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
-                PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
+            PhpCsFixer\Config\Name::fromString($faker->word()),
+            PhpCsFixer\Config\PhpVersion::create(
+                PhpCsFixer\Config\PhpVersion\Major::fromInt($faker->numberBetween(0)),
+                PhpCsFixer\Config\PhpVersion\Minor::fromInt($faker->numberBetween(0, 99)),
+                PhpCsFixer\Config\PhpVersion\Patch::fromInt($faker->numberBetween(0, 99)),
             ),
-            Rules::fromArray([
+            PhpCsFixer\Config\Rules::fromArray([
                 'foo' => false,
                 'header_comment' => false,
                 'quz' => true,
@@ -184,7 +179,7 @@ final class RuleSetTest extends Framework\TestCase
         self::assertEquals($ruleSet->name(), $mutated->name());
         self::assertEquals($ruleSet->phpVersion(), $mutated->phpVersion());
 
-        $expected = $ruleSet->rules()->merge(Rules::fromArray([
+        $expected = $ruleSet->rules()->merge(PhpCsFixer\Config\Rules::fromArray([
             'header_comment' => [
                 'comment_type' => 'PHPDoc',
                 'header' => \trim($header),

--- a/test/Unit/RulesTest.php
+++ b/test/Unit/RulesTest.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\PhpCsFixer\Config\Test\Unit;
 
-use Ergebnis\PhpCsFixer\Config\Rules;
-use Ergebnis\PhpCsFixer\Config\Test;
+use Ergebnis\PhpCsFixer;
 use PHPUnit\Framework;
 
 /**
@@ -24,11 +23,11 @@ use PHPUnit\Framework;
  */
 final class RulesTest extends Framework\TestCase
 {
-    use Test\Util\Helper;
+    use PhpCsFixer\Config\Test\Util\Helper;
 
     public function testEmptyReturnsRules(): void
     {
-        $rules = Rules::empty();
+        $rules = PhpCsFixer\Config\Rules::empty();
 
         self::assertSame([], $rules->toArray());
     }
@@ -45,14 +44,14 @@ final class RulesTest extends Framework\TestCase
             'foo' => true,
         ];
 
-        $rules = Rules::fromArray($value);
+        $rules = PhpCsFixer\Config\Rules::fromArray($value);
 
         self::assertSame($value, $rules->toArray());
     }
 
     public function testMergeReturnsRulesMergedWithRules(): void
     {
-        $one = Rules::fromArray([
+        $one = PhpCsFixer\Config\Rules::fromArray([
             'bar' => [
                 'baz' => [
                     'qux',
@@ -62,7 +61,7 @@ final class RulesTest extends Framework\TestCase
             'foo' => true,
         ]);
 
-        $two = Rules::fromArray([
+        $two = PhpCsFixer\Config\Rules::fromArray([
             'bar' => [
                 'quux' => [],
             ],
@@ -75,7 +74,7 @@ final class RulesTest extends Framework\TestCase
         self::assertNotSame($one, $mutated);
         self::assertNotSame($two, $mutated);
 
-        $expected = Rules::fromArray([
+        $expected = PhpCsFixer\Config\Rules::fromArray([
             'bar' => [
                 'quux' => [],
             ],


### PR DESCRIPTION
This pull request

- [x] enables and configures the `ReferenceNamespacedSymbolsRelativeToNamespacePrefixRector`
- [x] runs `make refactoring`