### PR TITLE
Enhancement: Enable `no_whitespace_in_empty_array` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`6.60.2...main`][6.60.2...main].
 
+### Changed
+
+- Enabled the `no_whitespace_in_empty_array` fixer ([#1401]), by [@localheinz]
+
 ## [`6.60.2`][6.60.2]
 
 For a full diff see [`6.60.1...6.60.2`][6.60.1...6.60.2].
@@ -2219,6 +2223,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1373]: https://github.com/ergebnis/php-cs-fixer-config/pull/1373
 [#1377]: https://github.com/ergebnis/php-cs-fixer-config/pull/1377
 [#1381]: https://github.com/ergebnis/php-cs-fixer-config/pull/1381
+[#1401]: https://github.com/ergebnis/php-cs-fixer-config/pull/1401
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -441,7 +441,7 @@ final class Php53
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -442,7 +442,7 @@ final class Php54
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -448,7 +448,7 @@ final class Php55
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -448,7 +448,7 @@ final class Php56
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -448,7 +448,7 @@ final class Php70
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -449,7 +449,7 @@ final class Php71
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -449,7 +449,7 @@ final class Php72
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -449,7 +449,7 @@ final class Php73
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -449,7 +449,7 @@ final class Php74
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -457,7 +457,7 @@ final class Php80
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -458,7 +458,7 @@ final class Php81
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -458,7 +458,7 @@ final class Php82
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -460,7 +460,7 @@ final class Php83
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -462,7 +462,7 @@ final class Php84
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/src/RuleSet/Php85.php
+++ b/src/RuleSet/Php85.php
@@ -462,7 +462,7 @@ final class Php85
                     'after_heredoc' => false,
                 ],
                 'no_whitespace_in_blank_line' => true,
-                'no_whitespace_in_empty_array' => false,
+                'no_whitespace_in_empty_array' => true,
                 'non_printable_character' => [
                     'use_escape_sequences_in_strings' => false,
                 ],

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -463,7 +463,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -464,7 +464,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -470,7 +470,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -470,7 +470,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -470,7 +470,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -471,7 +471,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -471,7 +471,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -471,7 +471,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -471,7 +471,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -479,7 +479,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -480,7 +480,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -480,7 +480,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -482,7 +482,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -484,7 +484,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],

--- a/test/Unit/RuleSet/Php85Test.php
+++ b/test/Unit/RuleSet/Php85Test.php
@@ -484,7 +484,7 @@ final class Php85Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
             ],
             'no_whitespace_in_blank_line' => true,
-            'no_whitespace_in_empty_array' => false,
+            'no_whitespace_in_empty_array' => true,
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => false,
             ],


### PR DESCRIPTION
This pull request

- [x] enables the `no_whitespace_in_empty_array` fixer

Follows #1398.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.95.0/doc/rules/array_notation/no_whitespace_in_empty_array.rst.