### PR TITLE
Enhancement: Use `ensure_single_line_for_single_argument` for `on_multiline` option of `method_argument_space` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.60.2...main`][6.60.2...main].
 ### Changed
 
 - Enabled the `no_whitespace_in_empty_array` fixer ([#1401]), by [@localheinz]
+- Started using `ensure_single_line_for_single_argument` for `on_multiline` option of `method_argument_space` fixer ([#1402]), by [@localheinz]
 
 ## [`6.60.2`][6.60.2]
 
@@ -2224,6 +2225,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1377]: https://github.com/ergebnis/php-cs-fixer-config/pull/1377
 [#1381]: https://github.com/ergebnis/php-cs-fixer-config/pull/1381
 [#1401]: https://github.com/ergebnis/php-cs-fixer-config/pull/1401
+[#1402]: https://github.com/ergebnis/php-cs-fixer-config/pull/1402
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -287,7 +287,7 @@ final class Php53
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -288,7 +288,7 @@ final class Php54
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -292,7 +292,7 @@ final class Php55
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -292,7 +292,7 @@ final class Php56
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -292,7 +292,7 @@ final class Php70
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -292,7 +292,7 @@ final class Php71
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -292,7 +292,7 @@ final class Php72
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -292,7 +292,7 @@ final class Php73
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -292,7 +292,7 @@ final class Php74
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -294,7 +294,7 @@ final class Php80
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -295,7 +295,7 @@ final class Php81
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -295,7 +295,7 @@ final class Php82
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -297,7 +297,7 @@ final class Php83
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -297,7 +297,7 @@ final class Php84
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/src/RuleSet/Php85.php
+++ b/src/RuleSet/Php85.php
@@ -297,7 +297,7 @@ final class Php85
                     'after_heredoc' => false,
                     'attribute_placement' => 'standalone',
                     'keep_multiple_spaces_after_comma' => false,
-                    'on_multiline' => 'ensure_fully_multiline',
+                    'on_multiline' => 'ensure_single_line_for_single_argument',
                 ],
                 'method_chaining_indentation' => true,
                 'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -309,7 +309,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -310,7 +310,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -314,7 +314,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -314,7 +314,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -314,7 +314,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -314,7 +314,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -314,7 +314,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -314,7 +314,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -314,7 +314,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -316,7 +316,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -317,7 +317,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -317,7 +317,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -319,7 +319,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -319,7 +319,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,

--- a/test/Unit/RuleSet/Php85Test.php
+++ b/test/Unit/RuleSet/Php85Test.php
@@ -319,7 +319,7 @@ final class Php85Test extends ExplicitRuleSetTestCase
                 'after_heredoc' => false,
                 'attribute_placement' => 'standalone',
                 'keep_multiple_spaces_after_comma' => false,
-                'on_multiline' => 'ensure_fully_multiline',
+                'on_multiline' => 'ensure_single_line_for_single_argument',
             ],
             'method_chaining_indentation' => true,
             'modern_serialization_methods' => false,


### PR DESCRIPTION
This pull request

- [x] uses `ensure_single_line_for_single_argument` for `on_multiline` option of `method_argument_space` fixer

Follows #1398.

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.95.0/doc/rules/function_notation/method_argument_space.rst.