### PR TITLE
Enhancement: Enable `make_version_complete` option of `PhpCsFixerCustomFixers/php_unit_requires_constraint` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`6.61.1...main`][6.61.1...main].
 ### Changed
 
 - Updated `kubawerlos/php-cs-fixer-custom-fixers` ([#1412]), by [@dependabot]
+- Enabled `make_version_complete` option of `PhpCsFixerCustomFixers/php_unit_requires_constraint` fixer ([#1415]), by [@localheinz]
 
 ## [`6.61.1`][6.61.1]
 
@@ -2248,6 +2249,7 @@ For a full diff see [`d899e77...1.0.0`][d899e77...1.0.0].
 [#1402]: https://github.com/ergebnis/php-cs-fixer-config/pull/1402
 [#1404]: https://github.com/ergebnis/php-cs-fixer-config/pull/1404
 [#1412]: https://github.com/ergebnis/php-cs-fixer-config/pull/1412
+[#1415]: https://github.com/ergebnis/php-cs-fixer-config/pull/1415
 
 [@dependabot]: https://github.com/apps/dependabot
 [@linuxjuggler]: https://github.com/linuxjuggler

--- a/src/RuleSet/Php53.php
+++ b/src/RuleSet/Php53.php
@@ -57,7 +57,7 @@ final class Php53
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php54.php
+++ b/src/RuleSet/Php54.php
@@ -57,7 +57,7 @@ final class Php54
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php55.php
+++ b/src/RuleSet/Php55.php
@@ -57,7 +57,7 @@ final class Php55
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php56.php
+++ b/src/RuleSet/Php56.php
@@ -57,7 +57,7 @@ final class Php56
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php70.php
+++ b/src/RuleSet/Php70.php
@@ -57,7 +57,7 @@ final class Php70
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -57,7 +57,7 @@ final class Php71
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -57,7 +57,7 @@ final class Php72
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -57,7 +57,7 @@ final class Php73
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -57,7 +57,7 @@ final class Php74
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -57,7 +57,7 @@ final class Php80
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -57,7 +57,7 @@ final class Php81
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -57,7 +57,7 @@ final class Php82
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'align_multiline_comment' => [

--- a/src/RuleSet/Php83.php
+++ b/src/RuleSet/Php83.php
@@ -58,7 +58,7 @@ final class Php83
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'PhpCsFixerCustomFixers/typed_class_constant' => true,

--- a/src/RuleSet/Php84.php
+++ b/src/RuleSet/Php84.php
@@ -58,7 +58,7 @@ final class Php84
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'PhpCsFixerCustomFixers/typed_class_constant' => true,

--- a/src/RuleSet/Php85.php
+++ b/src/RuleSet/Php85.php
@@ -58,7 +58,7 @@ final class Php85
                 ],
                 'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
                 'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                    'make_version_complete' => false,
+                    'make_version_complete' => true,
                 ],
                 'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
                 'PhpCsFixerCustomFixers/typed_class_constant' => true,

--- a/test/Unit/RuleSet/Php53Test.php
+++ b/test/Unit/RuleSet/Php53Test.php
@@ -79,7 +79,7 @@ final class Php53Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php54Test.php
+++ b/test/Unit/RuleSet/Php54Test.php
@@ -79,7 +79,7 @@ final class Php54Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php55Test.php
+++ b/test/Unit/RuleSet/Php55Test.php
@@ -79,7 +79,7 @@ final class Php55Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php56Test.php
+++ b/test/Unit/RuleSet/Php56Test.php
@@ -79,7 +79,7 @@ final class Php56Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php70Test.php
+++ b/test/Unit/RuleSet/Php70Test.php
@@ -79,7 +79,7 @@ final class Php70Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -79,7 +79,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -79,7 +79,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -79,7 +79,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -79,7 +79,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -79,7 +79,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -79,7 +79,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php82Test.php
+++ b/test/Unit/RuleSet/Php82Test.php
@@ -79,7 +79,7 @@ final class Php82Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'align_multiline_comment' => [

--- a/test/Unit/RuleSet/Php83Test.php
+++ b/test/Unit/RuleSet/Php83Test.php
@@ -80,7 +80,7 @@ final class Php83Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'PhpCsFixerCustomFixers/typed_class_constant' => true,

--- a/test/Unit/RuleSet/Php84Test.php
+++ b/test/Unit/RuleSet/Php84Test.php
@@ -80,7 +80,7 @@ final class Php84Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'PhpCsFixerCustomFixers/typed_class_constant' => true,

--- a/test/Unit/RuleSet/Php85Test.php
+++ b/test/Unit/RuleSet/Php85Test.php
@@ -80,7 +80,7 @@ final class Php85Test extends ExplicitRuleSetTestCase
             ],
             'PhpCsFixerCustomFixers/no_duplicated_imports' => true,
             'PhpCsFixerCustomFixers/php_unit_requires_constraint' => [
-                'make_version_complete' => false,
+                'make_version_complete' => true,
             ],
             'PhpCsFixerCustomFixers/phpdoc_types_comma_spaces' => true,
             'PhpCsFixerCustomFixers/typed_class_constant' => true,


### PR DESCRIPTION
This pull request

- [x] enables `make_version_complete` option of `PhpCsFixerCustomFixers/php_unit_requires_constraint` fixer

Follows #1412.