### PR TITLE
Fix: Correct stale `actions/checkout` version comment in `renew.yaml`

### DIFF
--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.2  # zizmor: ignore[artipacked]
+        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6.0.3  # zizmor: ignore[artipacked]
         with:
           token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
 


### PR DESCRIPTION
This pull request

- [x] corrects the stale `actions/checkout` version comment in `renew.yaml`